### PR TITLE
Add support for multi-channel bruker acquisition

### DIFF
--- a/src/IO/Brukerfile.jl
+++ b/src/IO/Brukerfile.jl
@@ -360,7 +360,7 @@ function recoData(f::BrukerFile)
   #end
 
   I = open(recoFilename,"r") do fd
-    read!(fd,Array{Int16,3}(undef,N...))
+    read!(fd,Array{Int16,length(N)}(undef,N...))
   end
   return map(Float32,I)
 end


### PR DESCRIPTION
I have a 2D and 3D FLASH datasets that can be added to a test if you want ?
The direct reconstruction is working for both.