### PR TITLE
add test for Bruker multichannel acquisition

### DIFF
--- a/test/testBrukerFile.jl
+++ b/test/testBrukerFile.jl
@@ -22,7 +22,30 @@ save(fout, acq)
 Iloaded = recoData(b)
 @test size(Iloaded) == (128, 128, 15)
 
+## Test reconstruction for multi-coil datasets (2D and 3D FLASH)
+listBrukFiles = ["2D_FLASH","3D_FLASH"]
+listNormValues = [0.02, 0.15]
 
+for i = 1:length(listBrukFiles)
+    b = BrukerFile( joinpath(datadir, "BrukerFile", listBrukFiles[i]) )
+    raw = RawAcquisitionData(b)
+    acq = AcquisitionData(raw)
+    params = Dict{Symbol, Any}()
+    params[:reco] = "direct"
+    if (acq.encodingSize[3]>1)
+        params[:reconSize] = (acq.encodingSize[1],acq.encodingSize[2],acq.encodingSize[3]);
+    else
+        params[:reconSize] = (acq.encodingSize[1],acq.encodingSize[2]);
+    end
+    Ireco = reconstruction(acq, params);
+    @test size(Ireco) == (raw.params["encodedSize"][1], raw.params["encodedSize"][2], raw.params["encodedSize"][3], 1, raw.params["receiverChannels"])
 
+    Isos = sqrt.(sum(abs.(Ireco).^2,dims=5));
+    Isos = Isos ./ maximum(Isos);
 
+    I2dseq = recoData(b)
+    I2dseq = I2dseq ./ maximum(I2dseq);
+
+    @test norm(vec(I2dseq)-vec(Isos))/norm(vec(I2dseq)) < listNormValues[i]
+end
 end


### PR DESCRIPTION
The test is working but the RMSE for 3D is high (> 10%) and for 2D (<2%)

If I check the plot I get for 2D :
![plot_83](https://user-images.githubusercontent.com/12255163/151359084-a065a775-732c-4101-8ee0-e04969d7a9c6.png)

And for 3D :
![plot_82](https://user-images.githubusercontent.com/12255163/151359123-d0a29741-636d-4390-b9bf-c5d2be26b2d6.png)

Maybe the scaling is part of the problem but the most important error is at the boundaries. 
I checked and I don't have an offset in the acquisition
```
##$PVM_SPackArrPhase1Offset=( 1 )
0
##$PVM_SPackArrPhase2Offset=( 1 )
0
##$PVM_SPackArrSliceOffset=( 1 )
0
```

Maybe an offset created by the fft  in the 3rd direction ?

Any thoughts ?

By the way, the offset in phase/partition is not handle in the reconstruction I think ? I yes, should I open an issue as a reminder ? (I might have some codes for that under matlab)