### PR TITLE
Any Complex types are supported

### DIFF
--- a/src/Datatypes/RawAcqData.jl
+++ b/src/Datatypes/RawAcqData.jl
@@ -212,14 +212,14 @@ function rawdata(f::RawAcquisitionData; slice::Int=1, contrast::Int=1, repetitio
   # assume the same number of samples for all profiles
   numSampPerProfile, numChan = size(f.profiles[idx[1]].data)
   numSampPerProfile -= (f.profiles[idx[1]].head.discard_pre+f.profiles[idx[1]].head.discard_post)
-  kdata = zeros(ComplexF64, numSampPerProfile, numEncSt, numChan)
+  kdata = zeros(typeof(f.profiles[1].data[1, 1]), numSampPerProfile, numEncSt, numChan)
 
   # store one profile (kspace data) for each unique encoding status
   cnt = 1
   for l in idx[idx_unique] # TODO: set of profiles (with unique encoding status)
     i1 = f.profiles[l].head.discard_pre + 1
     i2 = i1+numSampPerProfile-1
-    kdata[:,cnt,:] .= ComplexF64.(f.profiles[l].data[i1:i2, :])
+    kdata[:,cnt,:] .= f.profiles[l].data[i1:i2, :]
     cnt += 1
   end
 

--- a/src/Reconstruction/DirectReconstruction.jl
+++ b/src/Reconstruction/DirectReconstruction.jl
@@ -14,8 +14,8 @@ input:
 """
 function reconstruction_direct(acqData::AcquisitionData
                                   , reconSize::NTuple{D,Int64}
-                                  , weights::Vector{Vector{ComplexF64}}
-                                  , correctionMap::Array{ComplexF64}=ComplexF64[]) where D
+                                  , weights::Vector{Vector{T}}
+                                  , correctionMap::Array{T}=T[]) where {D,T <: Complex}
 
   encDims = dims(trajectory(acqData))
   if encDims!=D
@@ -23,7 +23,7 @@ function reconstruction_direct(acqData::AcquisitionData
   end
 
   numContr, numChan, numSl = numContrasts(acqData), numChannels(acqData), numSlices(acqData)
-  Ireco = zeros(ComplexF64, prod(reconSize), numSl, numContr, numChan)
+  Ireco = zeros(T, prod(reconSize), numSl, numContr, numChan)
 
   p = Progress(numSl*numChan*numContr, 1, "Direct Reconstruction...")
 

--- a/src/Reconstruction/RecoParameters.jl
+++ b/src/Reconstruction/RecoParameters.jl
@@ -19,7 +19,8 @@ function setupDirectReco(acqData::AcquisitionData, recoParams::Dict)
   reconSize = recoParams[:reconSize]
   weights = samplingDensity(acqData,recoParams[:reconSize])
   # field map
-  cmap = get(recoParams, :cmap, ComplexF64[])
+  dType = typeof(acqData.kdata[1,1,1][1])
+  cmap = get(recoParams, :cmap, dType[])
 
   return reconSize, weights, cmap
 end
@@ -71,6 +72,7 @@ builds relevant parameters and operators from the entries in `recoParams`
 """
 function setupIterativeReco(acqData::AcquisitionData, recoParams::Dict)
 
+  dType = typeof(acqData.kdata[1,1,1][1])
   red3d = dims(trajectory(acqData,1))==2 && length(recoParams[:reconSize])==3
   if red3d  # acqData is 3d data converted to 2d
     reconSize = (recoParams[:reconSize][2], recoParams[:reconSize][3])
@@ -85,7 +87,7 @@ function setupIterativeReco(acqData::AcquisitionData, recoParams::Dict)
     weights = samplingDensity(acqData,reconSize)
   else
     numContr = numContrasts(acqData)
-    weights = Array{Vector{ComplexF64}}(undef,numContr)
+    weights = Array{Vector{dType}}(undef,numContr)
     for contr=1:numContr
       numNodes = size(acqData.kdata[contr],1)
       weights[contr] = [1.0/sqrt(prod(reconSize)) for node=1:numNodes]
@@ -116,7 +118,7 @@ function setupIterativeReco(acqData::AcquisitionData, recoParams::Dict)
   solvername = get(recoParams, :solver, "fista")
 
   # sensitivity maps
-  senseMaps = get(recoParams, :senseMaps, ComplexF64[])
+  senseMaps = get(recoParams, :senseMaps, dType[])
   if red3d && !isempty(senseMaps) # make sure the dimensions match the trajectory dimensions
     senseMaps = permutedims(senseMaps,[2,3,1,4])
   end


### PR DESCRIPTION
I used a lot of `dType = = typeof(acqData.kdata[1,1,1][1])`

Is it ok like that or do you prefer to add a acqdataType in the struct `AcquisitionData` ?

I had to use `D <: Complex` because `Complex{AbstractFloat}` is not working maybe it exists another possibility ?