### PR TITLE
Fix typo in trajectory function and add 32-bit test for non-CS reconstructions

### DIFF
--- a/src/Datatypes/RawAcqData.jl
+++ b/src/Datatypes/RawAcqData.jl
@@ -120,7 +120,7 @@ function trajectory(f::RawAcquisitionData; slice::Int=1, contrast::Int=1)
 
     traj_ = reshape(traj[:,:,:,:,1,1], D, :)
     # tr = Trajectory(traj_, size(traj_,3), size(traj_,2), circular=true)
-    tr = Trajectory(traj_, size(traj_,3), size(traj_,2), circular=true, times=vec(times[:,:,:,1,1]))
+    tr = Trajectory(traj_, size(traj,3), size(traj,2), circular=true, times=vec(times[:,:,:,1,1]))
   end
   return tr
 end

--- a/test/testReconstruction.jl
+++ b/test/testReconstruction.jl
@@ -206,7 +206,7 @@ function testSENSEReco(N = 64)
   params[:numSamplingPerProfile] = div(N*N,2)
   params[:windings] = div(N,4)
   params[:AQ] = 3.0e-2
-  params[:senseMaps] = ComplexF32.(coilsens)
+  params[:senseMaps] = coilsens
 
   # do simulation
   acqData = simulation(I, params)


### PR DESCRIPTION
I noticed when converting between RawAcquisitionData and AcquisitionData that some trajectory information wasn't getting carried over, resulting in multiple interleaves being appended upon conversion. This is due to a typo in the trajectory function, where there are underscores where they shouldn't be (i.e traj_ vs traj). I have removed them.

**UPDATE**

I have been poking around in the test files and found that although all tests pass with #67, the tests for reconstruction which are not CS recons use 64-bit data for the kspace data and sensitivity maps. The default for ISMRMRD is 32 bit, so there should be a test for 32 bit reconstructions using the standard SENSE reconstructions. I wrote one (included in this PR) and it is currently failing on the master. This reflects my experience with my reconstruction pipeline throwing errors for the same reason after pulling the most recent changes. 