### PR TITLE
Reco Bruker 3DUTE initial implementation

### DIFF
--- a/MRIBase/src/Datatypes/AcqData.jl
+++ b/MRIBase/src/Datatypes/AcqData.jl
@@ -223,8 +223,8 @@ function samplingDensity(acqData::AcquisitionData{T},shape::Tuple) where T
     else
       nodes = kspaceNodes(tr)
     end
-    plan = plan_nfft(nodes, shape, m=4, σ=1.25)
-    weights[echo] = sqrt.(sdc(plan, iters=3))
+    plan = plan_nfft(nodes, shape, m=2, σ=2)
+    weights[echo] = sqrt.(sdc(plan, iters=10))
   end
   return weights
 end

--- a/MRIBase/src/Datatypes/RawAcqData.jl
+++ b/MRIBase/src/Datatypes/RawAcqData.jl
@@ -125,6 +125,54 @@ function MRIBase.trajectory(f::RawAcquisitionData; slice::Int=1, contrast::Int=1
   return tr
 end
 
+"""
+  trajectoryCustom(f::RawAcquisitionData; slice::Int=1, contrast::Int=1)
+
+returns the `Trajectory` for given `slice` and `contrast` of a `RawAcquisitionData`.
+"""
+function trajectoryCustom(f::RawAcquisitionData; slice::Int=1, contrast::Int=1)
+  name  = f.params["trajectory"]
+  sl = slices(f)
+  rep = repetitions(f)
+  contr = contrasts(f)
+
+  numSl = length(unique(sl))
+  numRep = length(unique(rep))
+  numContr = length(unique(contr))
+
+  numProf = Int(length(f.profiles)/(numSl * numRep * numContr))
+
+  # assume constant number of samplings per profile
+  numSampPerProfile = size(f.profiles[1].data,1)
+  numChan = size(f.profiles[1].data,2)
+  D = Int(f.profiles[1].head.trajectory_dimensions)
+
+  # remove data that should be discarded
+  i1 = f.profiles[1].head.discard_pre + 1
+  i2 = numSampPerProfile - f.profiles[1].head.discard_post
+
+  traj = zeros(Float32, D, length(i1:i2), numProf, 1, numSl, numRep)
+  times = zeros(Float32, length(i1:i2), numProf, 1, numSl, numRep)
+
+  counter = zeros(Int,numSl,numRep) #counter for sl and rep
+  for l=1:length(f.profiles)
+    if f.profiles[l].head.idx.slice+1 != slice || f.profiles[l].head.idx.contrast+1 != contrast
+      continue
+    end
+    counter[sl[l]-minimum(sl)+1,rep[l]-minimum(rep)+1] = counter[sl[l]-minimum(sl)+1,rep[l]-minimum(rep)+1] + 1
+    idx_tmp = counter[sl[l]-minimum(sl)+1,rep[l]-minimum(rep)+1]
+
+    traj[:, :, idx_tmp, 1, sl[l]-minimum(sl)+1, rep[l]-minimum(rep)+1] .= f.profiles[l].traj[:,i1:i2]
+    dt = f.profiles[l].head.sample_time_us*1e-6
+    times[:, idx_tmp, 1, sl[l]-minimum(sl)+1, rep[l]-minimum(rep)+1] .= 0:dt:(length(i1:i2)-1)*dt
+  end
+
+  traj_ = reshape(traj[:,:,:,:,1,1], D, :)
+  # tr = Trajectory(traj_, size(traj_,3), size(traj_,2), circular=true)
+  tr = Trajectory(traj_, size(traj,3), size(traj,2), circular=true, times=vec(times[:,:,:,1,1]))
+
+  return tr
+end
 
 function sequence(f::RawAcquisitionData)
   # TODO
@@ -226,6 +274,46 @@ function rawdata(f::RawAcquisitionData; slice::Int=1, contrast::Int=1, repetitio
   return reshape(kdata, :, numChan)
 end
 
+"""
+    rawdataCustom(f::RawAcquisitionData)
+
+returns the rawdata contained `RawAcquisitionData` object for custom trajectory
+The output is an `Array{Matrix{ComplexF64},3}`, which can be stored in a `AcquisitionData` object.
+"""
+function rawdataCustom(f::RawAcquisitionData; slice::Int=1, contrast::Int=1, repetition::Int=1)
+
+  sl = slices(f)
+  rep = repetitions(f)
+  contr = contrasts(f)
+  idx_sl = findall(x->x==slice,sl)
+  idx_contr = findall(x->x==contrast,contr)
+  idx_rep = findall(x->x==repetition,rep)
+  idx = intersect(idx_sl,idx_contr,idx_rep)
+
+  numSl = length(unique(sl))
+  numRep = length(unique(rep))
+  numContr = length(unique(contr))
+  numProf = Int(length(f.profiles)/(numSl * numRep * numContr))
+
+    # allocate space for k-space data
+  # assume the same number of samples for all profiles
+  numSampPerProfile, numChan = size(f.profiles[idx[1]].data)
+  numSampPerProfile -= (f.profiles[idx[1]].head.discard_pre+f.profiles[idx[1]].head.discard_post)
+  kdata = zeros(typeof(f.profiles[1].data[1, 1]), numSampPerProfile, numProf, numChan)
+
+  cnt = 1
+  for l=1:length(f.profiles)
+    if f.profiles[l].head.idx.slice+1 != slice || f.profiles[l].head.idx.contrast+1 != contrast || f.profiles[l].head.idx.repetition+1 != repetition
+      continue
+    end
+    i1 = f.profiles[l].head.discard_pre + 1
+    i2 = i1+numSampPerProfile-1
+    kdata[:,cnt,:] .= f.profiles[l].data[i1:i2, :]
+    cnt += 1
+  end
+
+  return reshape(kdata, :, numChan)
+end
 
 """
     AcquisitionData(f::RawAcquisitionData; estimateProfileCenter::Bool=false)
@@ -242,10 +330,16 @@ function AcquisitionData(f::RawAcquisitionData; estimateProfileCenter::Bool=fals
   # tr = [trajectory(f,contrast=contr) for contr=1:numContr]
   # subsampleIdx = [subsampleIndices(f,contrast=contr,estimateProfileCenter=estimateProfileCenter) for contr=1:numContr]
   # kdata = [rawdata(f; contrast=i, slice=j, repetition=k) for i=1:numContr, j=1:numSl, k=1:numRep]
-  tr = [trajectory(f,contrast=contr) for contr=contrs]
-  subsampleIdx = [subsampleIndices(f,contrast=contr,estimateProfileCenter=estimateProfileCenter) for contr=contrs]
-  kdata = [rawdata(f; contrast=i, slice=j, repetition=k) for i=contrs, j=sls, k=reps]
 
+  if (f.params["trajectory"] == "custom")
+      tr = [trajectoryCustom(f,contrast=contr) for contr=contrs]
+      subsampleIdx = nothing
+      kdata = [rawdataCustom(f; contrast=i, slice=j, repetition=k) for i=contrs, j=sls, k=reps]
+  else
+      tr = [trajectory(f,contrast=contr) for contr=contrs]
+      subsampleIdx = [subsampleIndices(f,contrast=contr,estimateProfileCenter=estimateProfileCenter) for contr=contrs]
+      kdata = [rawdata(f; contrast=i, slice=j, repetition=k) for i=contrs, j=sls, k=reps]
+  end
   return AcquisitionData(tr, kdata,
                           idx=subsampleIdx,
                           encodingSize=collect(f.params["encodedSize"]),

--- a/MRIBase/src/Datatypes/RawAcqData.jl
+++ b/MRIBase/src/Datatypes/RawAcqData.jl
@@ -75,6 +75,29 @@ returns the `Trajectory` for given `slice` and `contrast` of a `RawAcquisitionDa
 """
 function MRIBase.trajectory(f::RawAcquisitionData; slice::Int=1, contrast::Int=1)
   name = get(f.params, "trajectory","cartesian")
+
+  sl = slices(f)
+  rep = repetitions(f)
+  contr = contrasts(f)
+
+  numSl = length(unique(sl))
+  numRep = length(unique(rep))
+  numContr = length(unique(contr))
+
+  encSt1 = encSteps1(f)
+  encSt2 = encSteps2(f)
+  numEncSt1 = length(unique(encSt1))
+  numEncSt2 = length(unique(encSt2))
+
+  # assume constant number of samplings per profile
+  numSampPerProfile = size(f.profiles[1].data,1)
+  numChan = size(f.profiles[1].data,2)
+  D = Int(f.profiles[1].head.trajectory_dimensions)
+
+  # remove data that should be discarded
+  i1 = f.profiles[1].head.discard_pre + 1
+  i2 = numSampPerProfile - f.profiles[1].head.discard_post
+
   if lowercase(name) == "cartesian"
     dim = ( maximum(encSteps2(f))==1 ? 2 : 3)
     if dim==3
@@ -85,26 +108,31 @@ function MRIBase.trajectory(f::RawAcquisitionData; slice::Int=1, contrast::Int=1
       tr = trajectory(Float32, "Cartesian", f.params["encodedSize"][2],
                                    f.params["encodedSize"][1])
     end
+
+  elseif (f.params["trajectory"]=="custom")
+    numProf = Int(length(f.profiles)/(numSl * numRep * numContr))
+
+    traj = zeros(Float32, D, length(i1:i2), numProf, 1, numSl, numRep)
+    times = zeros(Float32, length(i1:i2), numProf, 1, numSl, numRep)
+
+    counter = zeros(Int,numSl,numRep) #counter for sl and rep
+    for l=1:length(f.profiles)
+      if f.profiles[l].head.idx.slice+1 != slice || f.profiles[l].head.idx.contrast+1 != contrast
+        continue
+      end
+      counter[sl[l]-minimum(sl)+1,rep[l]-minimum(rep)+1] = counter[sl[l]-minimum(sl)+1,rep[l]-minimum(rep)+1] + 1
+      idx_tmp = counter[sl[l]-minimum(sl)+1,rep[l]-minimum(rep)+1]
+
+      traj[:, :, idx_tmp, 1, sl[l]-minimum(sl)+1, rep[l]-minimum(rep)+1] .= f.profiles[l].traj[:,i1:i2]
+      dt = f.profiles[l].head.sample_time_us*1e-6
+      times[:, idx_tmp, 1, sl[l]-minimum(sl)+1, rep[l]-minimum(rep)+1] .= 0:dt:(length(i1:i2)-1)*dt
+    end
+
+    traj_ = reshape(traj[:,:,:,:,1,1], D, :)
+    tr = Trajectory(traj_, size(traj,3), size(traj,2), circular=true, times=vec(times[:,:,:,1,1]))
+
   else
     name  = f.params["trajectory"]
-    encSt1 = encSteps1(f)
-    encSt2 = encSteps2(f)
-    sl = slices(f)
-    rep = repetitions(f)
-
-    numSl = length(unique(sl))
-    numRep = length(unique(rep))
-    numEncSt1 = length(unique(encSt1))
-    numEncSt2 = length(unique(encSt2))
-
-    # assume constant number of samplings per profile
-    numSampPerProfile = size(f.profiles[1].data,1)
-    numChan = size(f.profiles[1].data,2)
-    D = Int(f.profiles[1].head.trajectory_dimensions)
-
-    # remove data that should be discarded
-    i1 = f.profiles[1].head.discard_pre + 1
-    i2 = numSampPerProfile - f.profiles[1].head.discard_post
 
     traj = zeros(Float32, D, length(i1:i2), numEncSt1, numEncSt2, numSl, numRep)
     times = zeros(Float32, length(i1:i2), numEncSt1, numEncSt2, numSl, numRep)
@@ -122,55 +150,6 @@ function MRIBase.trajectory(f::RawAcquisitionData; slice::Int=1, contrast::Int=1
     # tr = Trajectory(traj_, size(traj_,3), size(traj_,2), circular=true)
     tr = Trajectory(traj_, size(traj,3), size(traj,2), circular=true, times=vec(times[:,:,:,1,1]))
   end
-  return tr
-end
-
-"""
-  trajectoryCustom(f::RawAcquisitionData; slice::Int=1, contrast::Int=1)
-
-returns the `Trajectory` for given `slice` and `contrast` of a `RawAcquisitionData`.
-"""
-function trajectoryCustom(f::RawAcquisitionData; slice::Int=1, contrast::Int=1)
-  name  = f.params["trajectory"]
-  sl = slices(f)
-  rep = repetitions(f)
-  contr = contrasts(f)
-
-  numSl = length(unique(sl))
-  numRep = length(unique(rep))
-  numContr = length(unique(contr))
-
-  numProf = Int(length(f.profiles)/(numSl * numRep * numContr))
-
-  # assume constant number of samplings per profile
-  numSampPerProfile = size(f.profiles[1].data,1)
-  numChan = size(f.profiles[1].data,2)
-  D = Int(f.profiles[1].head.trajectory_dimensions)
-
-  # remove data that should be discarded
-  i1 = f.profiles[1].head.discard_pre + 1
-  i2 = numSampPerProfile - f.profiles[1].head.discard_post
-
-  traj = zeros(Float32, D, length(i1:i2), numProf, 1, numSl, numRep)
-  times = zeros(Float32, length(i1:i2), numProf, 1, numSl, numRep)
-
-  counter = zeros(Int,numSl,numRep) #counter for sl and rep
-  for l=1:length(f.profiles)
-    if f.profiles[l].head.idx.slice+1 != slice || f.profiles[l].head.idx.contrast+1 != contrast
-      continue
-    end
-    counter[sl[l]-minimum(sl)+1,rep[l]-minimum(rep)+1] = counter[sl[l]-minimum(sl)+1,rep[l]-minimum(rep)+1] + 1
-    idx_tmp = counter[sl[l]-minimum(sl)+1,rep[l]-minimum(rep)+1]
-
-    traj[:, :, idx_tmp, 1, sl[l]-minimum(sl)+1, rep[l]-minimum(rep)+1] .= f.profiles[l].traj[:,i1:i2]
-    dt = f.profiles[l].head.sample_time_us*1e-6
-    times[:, idx_tmp, 1, sl[l]-minimum(sl)+1, rep[l]-minimum(rep)+1] .= 0:dt:(length(i1:i2)-1)*dt
-  end
-
-  traj_ = reshape(traj[:,:,:,:,1,1], D, :)
-  # tr = Trajectory(traj_, size(traj_,3), size(traj_,2), circular=true)
-  tr = Trajectory(traj_, size(traj,3), size(traj,2), circular=true, times=vec(times[:,:,:,1,1]))
-
   return tr
 end
 
@@ -249,6 +228,11 @@ function rawdata(f::RawAcquisitionData; slice::Int=1, contrast::Int=1, repetitio
   idx_rep = findall(x->x==repetition,rep)
   idx = intersect(idx_sl,idx_contr,idx_rep)
 
+  numSl = length(unique(sl))
+  numRep = length(unique(rep))
+  numContr = length(unique(contr))
+  numProf = Int(length(f.profiles)/(numSl * numRep * numContr))
+
   # number of unique combination of encoding statuses
   encSt1 = encSteps1(f)[idx]
   encSt2 = encSteps2(f)[idx]
@@ -260,49 +244,18 @@ function rawdata(f::RawAcquisitionData; slice::Int=1, contrast::Int=1, repetitio
   # assume the same number of samples for all profiles
   numSampPerProfile, numChan = size(f.profiles[idx[1]].data)
   numSampPerProfile -= (f.profiles[idx[1]].head.discard_pre+f.profiles[idx[1]].head.discard_post)
-  kdata = zeros(typeof(f.profiles[1].data[1, 1]), numSampPerProfile, numEncSt, numChan)
+  
+  if f.params["trajectory"] == "custom"
+    kdata = zeros(typeof(f.profiles[1].data[1, 1]), numSampPerProfile, numProf, numChan)
+    posIdx = 1:length(f.profiles)
+  else # cartesian case
+    kdata = zeros(typeof(f.profiles[1].data[1, 1]), numSampPerProfile, numEncSt, numChan)
+    posIdx = idx[idx_unique]
+  end
 
   # store one profile (kspace data) for each unique encoding status
   cnt = 1
-  for l in idx[idx_unique] # TODO: set of profiles (with unique encoding status)
-    i1 = f.profiles[l].head.discard_pre + 1
-    i2 = i1+numSampPerProfile-1
-    kdata[:,cnt,:] .= f.profiles[l].data[i1:i2, :]
-    cnt += 1
-  end
-
-  return reshape(kdata, :, numChan)
-end
-
-"""
-    rawdataCustom(f::RawAcquisitionData)
-
-returns the rawdata contained `RawAcquisitionData` object for custom trajectory
-The output is an `Array{Matrix{ComplexF64},3}`, which can be stored in a `AcquisitionData` object.
-"""
-function rawdataCustom(f::RawAcquisitionData; slice::Int=1, contrast::Int=1, repetition::Int=1)
-
-  sl = slices(f)
-  rep = repetitions(f)
-  contr = contrasts(f)
-  idx_sl = findall(x->x==slice,sl)
-  idx_contr = findall(x->x==contrast,contr)
-  idx_rep = findall(x->x==repetition,rep)
-  idx = intersect(idx_sl,idx_contr,idx_rep)
-
-  numSl = length(unique(sl))
-  numRep = length(unique(rep))
-  numContr = length(unique(contr))
-  numProf = Int(length(f.profiles)/(numSl * numRep * numContr))
-
-    # allocate space for k-space data
-  # assume the same number of samples for all profiles
-  numSampPerProfile, numChan = size(f.profiles[idx[1]].data)
-  numSampPerProfile -= (f.profiles[idx[1]].head.discard_pre+f.profiles[idx[1]].head.discard_post)
-  kdata = zeros(typeof(f.profiles[1].data[1, 1]), numSampPerProfile, numProf, numChan)
-
-  cnt = 1
-  for l=1:length(f.profiles)
+  for l in posIdx # TODO: set of profiles (with unique encoding status)
     if f.profiles[l].head.idx.slice+1 != slice || f.profiles[l].head.idx.contrast+1 != contrast || f.profiles[l].head.idx.repetition+1 != repetition
       continue
     end
@@ -311,9 +264,10 @@ function rawdataCustom(f::RawAcquisitionData; slice::Int=1, contrast::Int=1, rep
     kdata[:,cnt,:] .= f.profiles[l].data[i1:i2, :]
     cnt += 1
   end
-
+  
   return reshape(kdata, :, numChan)
 end
+
 
 """
     AcquisitionData(f::RawAcquisitionData; estimateProfileCenter::Bool=false)
@@ -331,15 +285,11 @@ function AcquisitionData(f::RawAcquisitionData; estimateProfileCenter::Bool=fals
   # subsampleIdx = [subsampleIndices(f,contrast=contr,estimateProfileCenter=estimateProfileCenter) for contr=1:numContr]
   # kdata = [rawdata(f; contrast=i, slice=j, repetition=k) for i=1:numContr, j=1:numSl, k=1:numRep]
 
-  if (f.params["trajectory"] == "custom")
-      tr = [trajectoryCustom(f,contrast=contr) for contr=contrs]
-      subsampleIdx = nothing
-      kdata = [rawdataCustom(f; contrast=i, slice=j, repetition=k) for i=contrs, j=sls, k=reps]
-  else
-      tr = [trajectory(f,contrast=contr) for contr=contrs]
-      subsampleIdx = [subsampleIndices(f,contrast=contr,estimateProfileCenter=estimateProfileCenter) for contr=contrs]
-      kdata = [rawdata(f; contrast=i, slice=j, repetition=k) for i=contrs, j=sls, k=reps]
-  end
+  
+  tr = [trajectory(f,contrast=contr) for contr=contrs]
+  subsampleIdx = [subsampleIndices(f,contrast=contr,estimateProfileCenter=estimateProfileCenter) for contr=contrs]
+  kdata = [rawdata(f; contrast=i, slice=j, repetition=k) for i=contrs, j=sls, k=reps]
+
   return AcquisitionData(tr, kdata,
                           idx=subsampleIdx,
                           encodingSize=collect(f.params["encodedSize"]),

--- a/MRIFiles/src/Bruker/Bruker.jl
+++ b/MRIFiles/src/Bruker/Bruker.jl
@@ -1,6 +1,7 @@
 export BrukerFile, recoData
 
 include("Jcampdx.jl")
+include("BrukerSequence.jl")
 
 
 function latin1toutf8(str::AbstractString)

--- a/MRIFiles/src/Bruker/Bruker.jl
+++ b/MRIFiles/src/Bruker/Bruker.jl
@@ -1,7 +1,6 @@
 export BrukerFile, recoData
 
 include("Jcampdx.jl")
-include("BrukerSequence.jl")
 
 
 function latin1toutf8(str::AbstractString)
@@ -234,6 +233,8 @@ end
 
 function MRIBase.RawAcquisitionData(b::BrukerFile)
   if isfile(joinpath(b.path, "fid"))
+    protocolName = acqProtocolName(b)
+    @info "Bruker protocol name : $protocolName"
     if acqProtocolName(b) == "UTE3D"
       return RawAcquisitionData_3DUTE(b)
     elseif acqProtocolName(b) == "SPIRAL"
@@ -243,6 +244,8 @@ function MRIBase.RawAcquisitionData(b::BrukerFile)
     end
   end
 end
+
+include("BrukerSequence.jl")
 
 function RawAcquisitionDataRawDataSpiral(b::BrukerFile)
   # Have not a way to read out this. Not sure if its true

--- a/MRIFiles/src/Bruker/BrukerSequence.jl
+++ b/MRIFiles/src/Bruker/BrukerSequence.jl
@@ -1,0 +1,127 @@
+export RawAcquisitionData_3DUTE
+
+function RawAcquisitionData_3DUTE(b::BrukerFile)
+    T = Complex{acqDataType(b)}
+
+    filename = joinpath(b.path, "fid")
+    filenameTraj = joinpath(b.path, "traj")
+
+    N = acqSize(b)
+    # The data is padded in case it is not a multiple of 1024 
+    # For multi-channel acquisition data at concatenate then padded to a multiple of 1024 bytes
+    numChannel = pvmEncNReceivers(b)
+    profileLength = Int((ceil(N[1]*numChannel*sizeof(T)/1024))*1024/sizeof(T))
+    numAvailableChannel = pvmEncAvailReceivers(b)
+    phaseFactor = acqPhaseFactor(b)
+    numSlices = acqNumSlices(b)
+    numEchos = acqNumEchos(b)
+    numEncSteps2 = length(N) == 3 ? N[3] : 1
+    numRep = acqNumRepetitions(b)
+
+    I = open(filename,"r") do fd
+      read!(fd,Array{T,7}(undef, profileLength,
+                                     numEchos,
+                                     phaseFactor,
+                                     numSlices,
+                                     div(N[2], phaseFactor),
+                                     numEncSteps2,
+                                     numRep))[1:N[1]*numChannel,:,:,:,:,:,:]
+    end
+
+    traj = open(filenameTraj,"r") do fd
+        read!(fd,Array{Float64,3}(undef, 3,N[1],
+                                       N[2]))
+    end
+
+    objOrd = acqObjOrder(b)
+    objOrd = objOrd.-minimum(objOrd)
+
+    gradMatrix = acqGradMatrix(b)
+
+    offset1 = acqReadOffset(b)
+    offset2 = acqPhase1Offset(b)
+    offset3 = ndims(b) == 2 ? acqSliceOffset(b) : acqPhase2Offset(b)
+
+    profiles = Profile[]
+    for nR = 1:numRep
+      for nEnc2 = 1:numEncSteps2
+        for nPhase2 = 1:div(N[2], phaseFactor)
+          for nSl = 1:numSlices
+            for nPhase1 = 1:phaseFactor
+              for nEcho=1:numEchos
+                  counter = EncodingCounters(kspace_encode_step_1=0,
+                                             kspace_encode_step_2=0,
+                                             average=0,
+                                             slice=objOrd[nSl],
+                                             contrast=nEcho-1,
+                                             phase=0,
+                                             repetition=nR-1,
+                                             set=0,
+                                             segment=0 )
+
+                  G = gradMatrix[:,:,nSl]
+                  read_dir = (G[1,1],G[2,1],G[3,1])
+                  phase_dir = (G[1,2],G[2,2],G[3,2])
+                  slice_dir = (G[1,3],G[2,3],G[3,3])
+
+                  # Not sure if the following is correct...
+                  pos = offset1[nSl]*G[:,1] +
+                        offset2[nSl]*G[:,2] +
+                        offset3[nSl]*G[:,3]
+
+                  position = (pos[1], pos[2], pos[3])
+
+                  head = AcquisitionHeader(number_of_samples=N[1], idx=counter,
+                                          read_dir=read_dir, phase_dir=phase_dir,
+                                          slice_dir=slice_dir, position=position,
+                                          center_sample=0,
+                                          available_channels = numAvailableChannel, #TODO
+                                          active_channels = numChannel,
+                                          trajectory_dimensions = 3,
+                                          sample_time_us = parse(Float64,b["PVM_DigDw"])/1000)
+                  
+                  dat = map(T, reshape(I[:,nEcho,nPhase1,nSl,nPhase2,nEnc2,nR],:,numChannel))
+                  push!(profiles, Profile(head,convert.(Float32,traj[:,:,nPhase2]),dat) )
+              end
+            end
+          end
+        end
+      end
+    end
+
+    params = Dict{String,Any}()
+    params["trajectory"] = "custom"
+    N = MRIFiles.acqSize(b)
+    if length(N) < 3
+      N_ = ones(Int,3)
+      N_[1:length(N)] .= N
+      N = N_
+    end
+    params["encodedSize"] = pvmMatrix(b)
+    F = acqFov(b)
+    params["encodedFOV"] = F
+    params["receiverChannels"] = numChannel
+    params["H1resonanceFrequency_Hz"] = round(Int, parse(Float64,b["SW"])*1000000)
+    params["studyID"] = b["VisuStudyId"]
+    #params["studyDescription"] = b["ACQ_scan_name"]
+    #params["studyInstanceUID"] =
+    params["referringPhysicianName"] = latin1toutf8(b["ACQ_operator"])
+
+    params["patientName"] = b["VisuSubjectName"]
+
+    params["measurementID"] = parse(Int64,b["VisuExperimentNumber"])
+    params["seriesDescription"] = b["ACQ_scan_name"]
+
+    params["institutionName"] = latin1toutf8(b["ACQ_institution"])
+    params["stationName"] = b["ACQ_station"]
+    params["systemVendor"] = "Bruker"
+
+    params["TR"] = acqRepetitionTime(b)
+    params["TE"] = acqEchoTime(b)
+    #params["TI"] = ???
+    params["flipAngle_deg"] = acqFlipAngle(b)
+    params["sequence_type"] = acqProtocolName(b)
+    params["echo_spacing"] = acqInterEchoTime(b)
+
+    return RawAcquisitionData(params, profiles)
+end

--- a/MRIFiles/src/Bruker/BrukerSequence.jl
+++ b/MRIFiles/src/Bruker/BrukerSequence.jl
@@ -89,39 +89,8 @@ function RawAcquisitionData_3DUTE(b::BrukerFile)
       end
     end
 
-    params = Dict{String,Any}()
+    params = brukerParams(b)
     params["trajectory"] = "custom"
-    N = MRIFiles.acqSize(b)
-    if length(N) < 3
-      N_ = ones(Int,3)
-      N_[1:length(N)] .= N
-      N = N_
-    end
     params["encodedSize"] = pvmMatrix(b)
-    F = acqFov(b)
-    params["encodedFOV"] = F
-    params["receiverChannels"] = numChannel
-    params["H1resonanceFrequency_Hz"] = round(Int, parse(Float64,b["SW"])*1000000)
-    params["studyID"] = b["VisuStudyId"]
-    #params["studyDescription"] = b["ACQ_scan_name"]
-    #params["studyInstanceUID"] =
-    params["referringPhysicianName"] = latin1toutf8(b["ACQ_operator"])
-
-    params["patientName"] = b["VisuSubjectName"]
-
-    params["measurementID"] = parse(Int64,b["VisuExperimentNumber"])
-    params["seriesDescription"] = b["ACQ_scan_name"]
-
-    params["institutionName"] = latin1toutf8(b["ACQ_institution"])
-    params["stationName"] = b["ACQ_station"]
-    params["systemVendor"] = "Bruker"
-
-    params["TR"] = acqRepetitionTime(b)
-    params["TE"] = acqEchoTime(b)
-    #params["TI"] = ???
-    params["flipAngle_deg"] = acqFlipAngle(b)
-    params["sequence_type"] = acqProtocolName(b)
-    params["echo_spacing"] = acqInterEchoTime(b)
-
     return RawAcquisitionData(params, profiles)
 end

--- a/src/Tools/Shutter.jl
+++ b/src/Tools/Shutter.jl
@@ -18,6 +18,22 @@ function circularShutter!(I::Matrix, radiusFactor::Number=1.0)
     end
 end
 
+function circularShutter!(I::Array{Complex{T}, 3}, radiusFactor::Float64=1.0) where T <: AbstractFloat
+    imgSize = size(I)
+    center = (imgSize[1]/2.0, imgSize[2]/2.0, imgSize[3]/2.0)
+    radius = maximum(center) * radiusFactor
+    # Applying filtering
+    for k=1:imgSize[3]
+        for j=1:imgSize[2]
+            for i=1:imgSize[1]
+                if sqrt((i-center[1])^2 + (j-center[2])^2 + (k-center[3])^2) > radius
+                    I[i,j,k] = 0
+                end
+            end
+        end
+    end
+end
+
 function getCircularMask(shape::Tuple, radiusFactor::Number=1.0)
   A = ones(Float64,shape)
   circularShutter!(A,radiusFactor)

--- a/test/testBrukerFile.jl
+++ b/test/testBrukerFile.jl
@@ -51,7 +51,7 @@ end
 
 # Reconstruction of 3DUTE
 @info "Reconstruction of 3DUTE"
-b = BrukerFile( joinpath(datadir, "BrukerFile", "UTE3D_NR2") )
+b = BrukerFile( joinpath(datadir, "BrukerFile", "3D_UTE_NR2") )
 
 raw = RawAcquisitionData(b);
 acq = AcquisitionData(raw);  # TODO vérification des modifications qui ont étaient effectuée

--- a/test/testBrukerFile.jl
+++ b/test/testBrukerFile.jl
@@ -48,4 +48,33 @@ for i = 1:length(listBrukFiles)
 
     @test norm(vec(I2dseq)-vec(Isos))/norm(vec(I2dseq)) < listNormValues[i]
 end
+
+# Reconstruction of 3DUTE
+@info "Reconstruction of 3DUTE"
+b = BrukerFile( joinpath(datadir, "BrukerFile", "UTE3D_NR2") )
+
+raw = RawAcquisitionData(b);
+acq = AcquisitionData(raw);  # TODO vérification des modifications qui ont étaient effectuée
+
+params = Dict{Symbol, Any}()
+params[:reco] = "direct"
+if (acq.encodingSize[3]>1)
+    params[:reconSize] = (acq.encodingSize[1],acq.encodingSize[2],acq.encodingSize[3]);
+else
+    params[:reconSize] = (acq.encodingSize[1],acq.encodingSize[2]);
+end
+
+Ireco = reconstruction(acq, params);
+
+Isos = sqrt.(sum(abs.(Ireco).^2,dims=5));
+Isos = Isos ./ maximum(Isos);
+I2dseq = recoData(b)
+I2dseq = I2dseq ./ maximum(I2dseq);
+# reorient
+I2dseq = permutedims(I2dseq,(2,1,3,4))
+I2dseq = circshift(I2dseq,(0,0,1,0))
+
+@test MRIReco.norm(vec(I2dseq)-vec(Isos))/MRIReco.norm(vec(I2dseq)) < 0.1
+
+
 end


### PR DESCRIPTION
**This PR is not suppose to be merged for now** 

# Goal
It is an initial implementation of a 3DUTE reconstruction from the standard 3D UTE Bruker acquisition.

# Test
You can find a testing script here with the associated datasets (a 3DUTE with a matrix of 96x96x96 and 2 NR)
https://drive.google.com/drive/folders/1roh0tRhAQTsqe27iKaHHhuGGi9n4MA65?usp=sharing

## Results of test.jl :

RMSE = 0.30 
![test](https://user-images.githubusercontent.com/12255163/163202833-d1e2a9d8-93e6-4d03-9c4c-4b26b43f5ccc.png)

# Remarks
- I had to change the oversampling for the nufft in order to estimates the weights in order to reach a good image quality.
- For now I have split the conversion from Bruker to Raw in a specific file with a lot of copy/paste from the `function RawAcquisitionDataFid(b::BrukerFile)`. We should discuss how to manage the factorization.
- I had to bypass the `encStep` problem by creating custom functions only called if : 
`if (f.params["trajectory"] == "custom")`
Again a lot of repetition with the standard functions but I am not using the EncStep1/EncStep2 (which are all equal to 0 during the conversion from bruker to acq).
- I have to try if standard reco works

# Discussions
1-  Reconstruction only return 1 repetition (the for loop is not available for NR)
2- Only one trajectory is stored during conversion from raw to acq, should we keep one for each NR,contrast,slices ?

Let me know what are your thoughts about that first try.
    

