### PR TITLE
Read Bruker method file only the first time

### DIFF
--- a/MRIFiles/src/Bruker/Bruker.jl
+++ b/MRIFiles/src/Bruker/Bruker.jl
@@ -57,7 +57,7 @@ function getindex(b::BrukerFile, parameter)#::String
       read(b.params, mpiParPath)
       b.mpiParRead = true
     end
-  else !b.methodRead 
+  elseif !b.methodRead
       methodpath = joinpath(b.path, "method")
       read(b.params, methodpath)
       b.methodRead = true
@@ -180,7 +180,7 @@ pvmTrajKy(b::BrukerFile) = parse.(Float32,b["PVM_TrajKy"])
 """
 brukerParams(b::BrukerFile)
 
-Generate a standard parameter dictionary from Bruker acquistion 
+Generate a standard parameter dictionary from Bruker acquistion
 Some fields needs to be filled outside lik
 
 """
@@ -249,7 +249,7 @@ include("BrukerSequence.jl")
 function RawAcquisitionDataRawDataSpiral(b::BrukerFile)
   # Have not a way to read out this. Not sure if its true
   T = Complex{Int32}
-  
+
   filename = joinpath(b.path, "rawdata.job0")
 
   profileLength = pvmTrajSamples(b)
@@ -280,7 +280,7 @@ function RawAcquisitionDataFid(b::BrukerFile)
     filename = joinpath(b.path, "fid")
 
     N = acqSize(b)
-    # The data is padded in case it is not a multiple of 1024 
+    # The data is padded in case it is not a multiple of 1024
     # For multi-channel acquisition data at concatenate then padded to a multiple of 1024 bytes
     numChannel = pvmEncNReceivers(b)
     profileLength = Int((ceil(N[1]*numChannel*sizeof(T)/1024))*1024/sizeof(T))
@@ -315,7 +315,7 @@ function RawAcquisitionDataFid(b::BrukerFile)
     offset1 = acqReadOffset(b)
     offset2 = acqPhase1Offset(b)
     offset3 = ndims(b) == 2 ? acqSliceOffset(b) : pvmEffPhase2Offset(b)
-    
+
     profiles = Profile[]
     for nR = 1:numRep
       for nEnc2 = 1:numEncSteps2
@@ -397,7 +397,7 @@ function recoData(f::BrukerFile,procno::Int=1)
     read!(fd,Array{T,length(N)+1}(undef,N...,nFrame))
   end
 
-  if(f["VisuCoreFrameType",procno] == ["REAL_IMAGE", "IMAGINARY_IMAGE"]) 
+  if(f["VisuCoreFrameType",procno] == ["REAL_IMAGE", "IMAGINARY_IMAGE"])
     @warn "1st half of image are the REAL part and 2nd half is the imaginary"
   end
 

--- a/test/testBrukerFile.jl
+++ b/test/testBrukerFile.jl
@@ -2,6 +2,8 @@
 
 @testset "BrukerFile read parameters" begin
     b = BrukerFile( joinpath(datadir, "BrukerFile", "2D_RARE") )
+    t1 = @elapsed b["ExcPulse1"]
+
     @test b["ExcPulse1"] == "(1.3125, 3200, 90, Yes, 3, 4200, 0.236151639875348, 0.200434548747244, 0, 50, 0.317196887605166, <\$ExcPulse1Shape>)"
     @test b["PVM_Fov"] == ["27","27"]
     @test b["PVM_FreqDriftYN"] == "Yes"
@@ -9,6 +11,10 @@
     @test b["VisuCoreWordType"] == "_16BIT_SGN_INT"
     @test b["VisuFGOrderDesc"][1] == Any[15.0, " <FG_SLICE>", " <>", 0.0, 2.0]
     @test b["VisuCoreDataOffs"] == repeat(["0","0","0"],5)
+
+    t2 = @elapsed b["ExcPulse1"]
+    @info "Read parameters timing" t1 t2
+    @test t2 < 0.0001
 end
 
 @testset "BrukerFile read 2dseq" begin


### PR DESCRIPTION
PR corresponding to issue #94 

- method file is only read one time. 
- A test has been added : read a parameters should take less than < 0.0001 s

---
# Results on my mac
┌ Info: Read parameters timing
│   t1 = 0.380862047
└   t2 = 1.51e-6