### PR TITLE
WIP: Implement partial reading for ISMRMRD files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,8 +45,8 @@ jobs:
         shell: julia --color=yes --project=. {0}
         run: |
           using Pkg
-          Pkg.add(PackageSpec(path=pwd(), subdir="MRIBase", rev="master"))
-          Pkg.add(PackageSpec(path=pwd(), subdir="MRIFiles", rev="master"))
+          Pkg.add(PackageSpec(path=pwd(), subdir="MRIBase"))
+          Pkg.add(PackageSpec(path=pwd(), subdir="MRIFiles"))
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1
@@ -65,8 +65,8 @@ jobs:
         shell: julia --color=yes --project=. {0}
         run: |
           using Pkg
-          Pkg.add(PackageSpec(path=pwd(), subdir="MRIBase", rev="master"))
-          Pkg.add(PackageSpec(path=pwd(), subdir="MRIFiles", rev="master"))
+          Pkg.add(PackageSpec(path=pwd(), subdir="MRIBase"))
+          Pkg.add(PackageSpec(path=pwd(), subdir="MRIFiles"))
       - run: |
           julia --project=docs -e '
             using Pkg

--- a/MRIFiles/src/ISMRMRD/HDF5Types.jl
+++ b/MRIFiles/src/ISMRMRD/HDF5Types.jl
@@ -219,6 +219,10 @@ struct HDF5_Acquisition
   data::HVL_T{Float32} #for some reason this is stored as float
 end
 
+struct HDF5_AcquisitionHeaderOnly
+  head::AcquisitionHeaderImmutable
+end
+
 function get_hdf5type_acquisition()
   off = i -> Cint(fieldoffset(HDF5_Acquisition,i))
   datatype = h5t_create(H5T_COMPOUND, sizeof(HDF5_Acquisition) )
@@ -236,6 +240,16 @@ function get_hdf5type_acquisition()
   h5t_insert(datatype, "data", off(3), vlvartype)
   h5t_close(vlvartype)
   #h5t_close(vartype)
+
+  return datatype
+end
+
+function get_hdf5type_acquisition_header_only()
+  off = i -> Cint(fieldoffset(HDF5_AcquisitionHeaderOnly,i))
+  datatype = h5t_create(H5T_COMPOUND, sizeof(HDF5_AcquisitionHeaderOnly) )
+  d1 = get_hdf5type_acquisitionheader()
+  h5t_insert(datatype, "head", off(1), d1)
+  h5t_close(d1)
 
   return datatype
 end

--- a/test/testISMRMRD.jl
+++ b/test/testISMRMRD.jl
@@ -1,6 +1,5 @@
 using MRIReco
 using Test
-using HTTP
 
 @testset "ISMRMRD" begin
 
@@ -36,6 +35,14 @@ acqCopy = RawAcquisitionData(fCopy)
 IrecoCopy = reconstruction(AcquisitionData(acqCopy), params)
 
 @test IrecoCopy == Ireco
+
+### test partial read
+
+acqPartial = RawAcquisitionData(f, slice=1) # slice 1 is not contained in the file
+
+@test length(acqPartial.profiles) == 0
+
+### test spiral data
 
 filename = joinpath(datadir, "simple_spiral.h5")
 


### PR DESCRIPTION
This is a first attempt to implement partial reading from ISMRMRD files (closes #76).
What is still missing is the fix of the header. I do not yet have an idea how to do that. We probably want to allow just `UnitRanges` for the applied `slice` argument.

@mrikasper @alexjaffray: I don't have data with multiple slices / repetitions at hand. Would be great if you could give this a test + help me fixing the header. The test should include timing. I expect that the sliced reading should be faster and acquire only the memory required for the slice. But I am only 90% sure about that.