### PR TITLE
reco of repetitions along dims=6

### DIFF
--- a/MRIBase/src/Datatypes/AcqData.jl
+++ b/MRIBase/src/Datatypes/AcqData.jl
@@ -1,4 +1,4 @@
-export AcquisitionData, kData, kDataCart kdataSingleSlice, convertUndersampledData,
+export AcquisitionData, kData, kDataCart, kdataSingleSlice, convertUndersampledData,
        changeEncodingSize2D, convert3dTo2d, samplingDensity,
        numContrasts, numChannels, numSlices, numRepetitions,
        encodingSize, fieldOfView, multiCoilData

--- a/MRIBase/src/Datatypes/AcqData.jl
+++ b/MRIBase/src/Datatypes/AcqData.jl
@@ -125,14 +125,14 @@ with dimension :
 """
 function kDataCart(acqData::AcquisitionData)
 nx, ny, nz = acqData.encodingSize[1:3]
-numChan, numSl = MRIFiles.numChannels(acqData), MRIFiles.numSlices(acqData)
+numChan, numSl = numChannels(acqData), numSlices(acqData)
 
 if nz > 1 && numSl > 1
     @warn "Multi slab 3D acquisitions are concatenate along the 3rd dimension"
 end
 
 numEcho = length(acqData.traj)
-numRep = MRIFiles.numRepetitions(acqData)
+numRep = numRepetitions(acqData)
 kdata = zeros(ComplexF64, nx * ny * nz,numSl,numChan, numEcho,numRep)
 for rep = 1:numRep
     for sl =1:numSl

--- a/MRIBase/src/Datatypes/AcqData.jl
+++ b/MRIBase/src/Datatypes/AcqData.jl
@@ -105,7 +105,12 @@ encoded with a 3d Cartesian sequence.
 """
 function AcquisitionData(kspace::Array{Complex{T},6}) where T
     sx,sy,sz,nCh,nEchos,nReps = size(kspace)
-    tr = MRIBase.CartesianTrajectory3D(T,sx,sy,numSlices=sz,TE=T(0),AQ=T(0))
+
+    if sz == 1
+        tr = MRIBase.CartesianTrajectory(T,sx,sy,TE=T(0),AQ=T(0))
+    else
+        tr = MRIBase.CartesianTrajectory3D(T,sx,sy,numSlices=sz,TE=T(0),AQ=T(0))
+    end
 
     kdata = [reshape(kspace,:,nCh) for i=1:nEchos, j=1:1, k=1:nReps]
     acq = AcquisitionData(tr,kdata)

--- a/MRIBase/src/Datatypes/AcqData.jl
+++ b/MRIBase/src/Datatypes/AcqData.jl
@@ -1,4 +1,4 @@
-export AcquisitionData, kData, kdataSingleSlice, convertUndersampledData,
+export AcquisitionData, kData, kDataCart kdataSingleSlice, convertUndersampledData,
        changeEncodingSize2D, convert3dTo2d, samplingDensity,
        numContrasts, numChannels, numSlices, numRepetitions,
        encodingSize, fieldOfView, multiCoilData

--- a/MRIBase/src/Datatypes/AcqData.jl
+++ b/MRIBase/src/Datatypes/AcqData.jl
@@ -1,4 +1,4 @@
-export AcquisitionData, kData, kDataCart,AcqDataFromKspace, kdataSingleSlice, convertUndersampledData,
+export AcquisitionData, kData, kDataCart, kdataSingleSlice, convertUndersampledData,
        changeEncodingSize2D, convert3dTo2d, samplingDensity,
        numContrasts, numChannels, numSlices, numRepetitions,
        encodingSize, fieldOfView, multiCoilData

--- a/src/Tools/ImageData.jl
+++ b/src/Tools/ImageData.jl
@@ -6,7 +6,7 @@ For this, it uses the information in `acqData`.
 The axies respectively describe the following coordinates:
 x, y, z, acqData.numEchoes, acqData.numCoils
 """
-function ImageUtils.makeAxisArray(I::AbstractArray{T,5}, acqData::AcquisitionData) where T
+function ImageUtils.makeAxisArray(I::AbstractArray{T,6}, acqData::AcquisitionData) where T
 
   offset = [0.0, 0.0, 0.0]*Unitful.mm
   spacing = fieldOfView(acqData)./encodingSize(acqData)*Unitful.mm
@@ -16,14 +16,15 @@ function ImageUtils.makeAxisArray(I::AbstractArray{T,5}, acqData::AcquisitionDat
 		   Axis{:y}(range(offset[2], step=spacing[2], length=size(I,2))),
 		   Axis{:z}(range(offset[3], step=spacing[3], length=size(I,3))),
 		   Axis{:echos}(1:size(I,4)),
-       Axis{:coils}(1:size(I,5)))
+       Axis{:coils}(1:size(I,5)),
+       Axis{:repetitions}(1:size(I,6)))
 
   #imMeta = ImageMeta(im, Dict{String,Any}())
   #return imMeta
   return im
 end
 
-function ImageUtils.makeAxisArray(I::AbstractArray{T,5}, spacing::Vector{Float64}) where T
+function ImageUtils.makeAxisArray(I::AbstractArray{T,6}, spacing::Vector{Float64}) where T
 
   offset = [0.0, 0.0, 0.0]*Unitful.mm
 
@@ -34,7 +35,8 @@ function ImageUtils.makeAxisArray(I::AbstractArray{T,5}, spacing::Vector{Float64
 		   Axis{:y}(range(offset[2], step=sp[2], length=size(I,2))),
 		   Axis{:z}(range(offset[3], step=sp[3], length=size(I,3))),
 		   Axis{:echos}(1:size(I,4)),
-       Axis{:coils}(1:size(I,5)))
+       Axis{:coils}(1:size(I,5)),
+       Axis{:repetitions}(1:size(I,6)))
 
   return im
 end

--- a/src/Tools/Nifti.jl
+++ b/src/Tools/Nifti.jl
@@ -6,7 +6,7 @@ function loadImage(filename::String)
   return makeAxisArray(ni.raw, pixelspacing)
 end
 
-function saveImage(filename::String, im::AbstractArray{T,5}, makeAbs::Bool=false) where T
+function saveImage(filename::String, im::AbstractArray{T,6}, makeAbs::Bool=false) where T
   voxel_size = ustrip.(uconvert.(u"m", pixelspacing(im)[1:3]))
 
   orientation = zeros(Float32, 3, 4)

--- a/test/testBrukerFile.jl
+++ b/test/testBrukerFile.jl
@@ -81,7 +81,7 @@ for i = 1:length(listBrukFiles)
         params[:reconSize] = (acq.encodingSize[1],acq.encodingSize[2]);
     end
     Ireco = reconstruction(acq, params);
-    @test size(Ireco) == (raw.params["encodedSize"][1], raw.params["encodedSize"][2], raw.params["encodedSize"][3], 1, raw.params["receiverChannels"])
+    @test size(Ireco) == (raw.params["encodedSize"][1], raw.params["encodedSize"][2], raw.params["encodedSize"][3], numContrasts(acq), raw.params["receiverChannels"], numRepetitions(acq))
 
     Isos = sqrt.(sum(abs.(Ireco).^2,dims=5));
     Isos = Isos ./ maximum(Isos);
@@ -118,7 +118,10 @@ I2dseq = I2dseq ./ maximum(I2dseq);
 I2dseq = permutedims(I2dseq,(2,1,3,4))
 I2dseq = circshift(I2dseq,(0,0,1,0))
 
-@test MRIReco.norm(vec(I2dseq[:,:,:,1])-vec(Isos))/MRIReco.norm(vec(I2dseq[:,:,:,1])) < 0.1
+#test reconstruction of repetitions
+@test size(Isos,6)==2
+@test MRIReco.norm(vec(I2dseq)-vec(Isos[:,:,:,1,1,:]))/MRIReco.norm(vec(I2dseq)) < 0.1
+
 end
 
 end

--- a/test/testISMRMRD.jl
+++ b/test/testISMRMRD.jl
@@ -21,7 +21,7 @@ params[:reco] = "direct"
 params[:reconSize] = (256,128) #this should be clear from context
 
 Ireco = reconstruction(AcquisitionData(acq), params)
-exportImage(joinpath(tmpdir,"recogre.png"), abs.(Ireco[:,:,1,1,1]))
+exportImage(joinpath(tmpdir,"recogre.png"), abs.(Ireco[:,:,1,1,1,1]))
 
 filenameCopy = joinpath(tmpdir, "simple_gre_copy.h5")
 fCopy = ISMRMRDFile(filenameCopy)
@@ -29,8 +29,8 @@ fCopy = ISMRMRDFile(filenameCopy)
 save(fCopy, acq)
 acqCopy = RawAcquisitionData(fCopy)
 
-@test convert(AcquisitionHeaderImmutable, acq.profiles[1].head) == 
-       convert(AcquisitionHeaderImmutable, acqCopy.profiles[1].head) 
+@test convert(AcquisitionHeaderImmutable, acq.profiles[1].head) ==
+       convert(AcquisitionHeaderImmutable, acqCopy.profiles[1].head)
 @test acqCopy.profiles[1].data == acq.profiles[1].data
 
 IrecoCopy = reconstruction(AcquisitionData(acqCopy), params)
@@ -46,7 +46,7 @@ params[:reco] = "direct"
 params[:reconSize] = (128,128) #this should be clear from context
 
 Ireco = reconstruction(AcquisitionData(f), params)
-exportImage(joinpath(tmpdir,"recospiral.png"), abs.(Ireco[:,:,1,1,1]))
+exportImage(joinpath(tmpdir,"recospiral.png"), abs.(Ireco[:,:,1,1,1,1]))
 
 filenameCopy = joinpath(tmpdir, "simple_spiral_copy.h5")
 fCopy = ISMRMRDFile(filenameCopy)
@@ -55,8 +55,8 @@ acq = RawAcquisitionData(f)
 save(fCopy, acq)
 acqCopy = RawAcquisitionData(f)
 
-@test convert(MRIReco.AcquisitionHeaderImmutable, acq.profiles[1].head) == 
-       convert(MRIReco.AcquisitionHeaderImmutable, acqCopy.profiles[1].head) 
+@test convert(MRIReco.AcquisitionHeaderImmutable, acq.profiles[1].head) ==
+       convert(MRIReco.AcquisitionHeaderImmutable, acqCopy.profiles[1].head)
 @test acqCopy.profiles[1].traj == acq.profiles[1].traj
 @test acqCopy.profiles[1].data == acq.profiles[1].data
 

--- a/test/testReconstruction.jl
+++ b/test/testReconstruction.jl
@@ -56,13 +56,59 @@ function testConvertKspace(N=32)
 
     acqCS = AcquisitionData(kspace_cs)
     params[:reco] = "direct"
-    params[:reconSize] = (N,N,1)
+    params[:reconSize] = (N,N)
 
     x_cs = reconstruction(acqCS, params)
     x_cs2 = ifftshift(ifft(ifftshift(kspace_cs)))
 
     @test (norm(vec(abs.(x_cs))-vec(abs.(x_cs2[:,:,1,1,1,1])))/norm(vec(abs.(x_cs2)))) < 1e-10
-  end
+end
+
+function testConvertKspace3D(N=32)
+    # image
+    x = shepp_logan(N)
+    x = repeat(x,1,1,N)
+
+    # simulation
+    params = Dict{Symbol, Any}()
+    params[:simulation] = "fast"
+    params[:trajName] = "Cartesian3D"
+    params[:numProfiles] = floor(Int64, N)
+    params[:numSamplingPerProfile] = N
+    params[:numSlices] = N
+
+    acqData = simulation(x, params)
+
+    #reco
+    params[:reco] = "direct"
+    params[:reconSize] = (N,N,N)
+
+    x_approx = reconstruction(acqData, params)
+    kspace = kDataCart(acqData)
+    x_approx2 = ifftshift(ifft(ifftshift(kspace)))
+    diff = abs.(x_approx2[:,:,:,1,1,1]) .- abs.(x)
+    any(diff .< 1e-10)
+    @test (norm(vec(x)-vec(abs.(x_approx2[:,:,:,1,1,1])))/norm(vec(x))) < 1e-10
+
+    ## undersample kspace
+    T = eltype(kspace)
+    mask_idx = MRIReco.sample_vdpoisson((N,N),2.0)
+    mask = zeros(T,N,N)
+    mask[mask_idx] .= 1
+    mask = repeat(mask,1,1,N,1,1,1)
+
+    kspace_cs = copy(kspace)
+    kspace_cs = kspace_cs .* mask
+
+    acqCS = AcquisitionData(kspace_cs)
+    params[:reco] = "direct"
+    params[:reconSize] = (N,N,N)
+
+    x_cs = reconstruction(acqCS, params)
+    x_cs2 = ifftshift(ifft(ifftshift(kspace_cs)))
+
+    @test (norm(vec(abs.(x_cs))-vec(abs.(x_cs2[:,:,:,1,1,1])))/norm(vec(abs.(x_cs2)))) < 1e-10
+end
 
 function testGriddingReco3d(N=32)
   sh = ComplexF64.(shepp_logan(N))
@@ -457,6 +503,7 @@ function testReco(N=32)
   @testset "Reconstructions" begin
     testGriddingReco()
     testConvertKspace()
+    testConvertKspace3D()
     testGriddingReco3d()
     sampling = ["random", "poisson", "vdPoisson"] # "lines"
     for samp in sampling

--- a/test/testReconstruction.jl
+++ b/test/testReconstruction.jl
@@ -18,13 +18,51 @@ function testGriddingReco(N=32)
 
   x_approx = reconstruction(acqData, params)
   @test (norm(vec(x)-vec(x_approx))/norm(vec(x))) < 1e-2
-
-  kspace = kDataCart(acqData)
-  im = ifftshift(ifft(ifftshift(kspace)))
-  diff = abs.(im[:,:,1,1,1,1]) .- abs.(x)
-  diff .< 1e-10
-  @test (norm(vec(x)-vec(abs.(im[:,:,1,1,1,1])))/norm(vec(x))) < 1e-10
 end
+
+# test gridding reco
+function testConvertKspace(N=32)
+    # image
+    x = shepp_logan(N)
+
+    # simulation
+    params = Dict{Symbol, Any}()
+    params[:simulation] = "fast"
+    params[:trajName] = "Cartesian"
+    params[:numProfiles] = floor(Int64, N)
+    params[:numSamplingPerProfile] = N
+
+    acqData = simulation(x, params)
+
+    #reco
+    params[:reco] = "direct"
+    params[:reconSize] = (N,N)
+
+    x_approx = reconstruction(acqData, params)
+    kspace = kDataCart(acqData)
+    x_approx2 = ifftshift(ifft(ifftshift(kspace)))
+    diff = abs.(x_approx2[:,:,1,1,1,1]) .- abs.(x)
+    any(diff .< 1e-10)
+    @test (norm(vec(x)-vec(abs.(x_approx2[:,:,1,1,1,1])))/norm(vec(x))) < 1e-10
+
+    ## undersample kspace
+    T = eltype(kspace)
+    mask_idx = MRIReco.sample_vdpoisson((N,N),2.0)
+    mask = zeros(T,N,N,1,1,1,1)
+    mask[mask_idx] .= 1
+
+    kspace_cs = copy(kspace)
+    kspace_cs = kspace_cs .* mask
+
+    acqCS = AcqDataFromKspace(kspace_cs)
+    params[:reco] = "direct"
+    params[:reconSize] = (N,N,1)
+
+    x_cs = reconstruction(acqCS, params)
+    x_cs2 = ifftshift(ifft(ifftshift(kspace_cs)))
+
+    @test (norm(vec(abs.(x_cs))-vec(abs.(x_cs2[:,:,1,1,1,1])))/norm(vec(abs.(x_cs2)))) < 1e-10
+  end
 
 function testGriddingReco3d(N=32)
   sh = ComplexF64.(shepp_logan(N))
@@ -418,6 +456,7 @@ end
 function testReco(N=32)
   @testset "Reconstructions" begin
     testGriddingReco()
+    testConvertKspace()
     testGriddingReco3d()
     sampling = ["random", "poisson", "vdPoisson"] # "lines"
     for samp in sampling

--- a/test/testReconstruction.jl
+++ b/test/testReconstruction.jl
@@ -54,7 +54,7 @@ function testConvertKspace(N=32)
     kspace_cs = copy(kspace)
     kspace_cs = kspace_cs .* mask
 
-    acqCS = AcqDataFromKspace(kspace_cs)
+    acqCS = AcquisitionData(kspace_cs)
     params[:reco] = "direct"
     params[:reconSize] = (N,N,1)
 

--- a/test/testReconstruction.jl
+++ b/test/testReconstruction.jl
@@ -18,6 +18,12 @@ function testGriddingReco(N=32)
 
   x_approx = reconstruction(acqData, params)
   @test (norm(vec(x)-vec(x_approx))/norm(vec(x))) < 1e-2
+
+  kspace = kDataCart(acqData)
+  im = ifftshift(ifft(ifftshift(kspace)))
+  diff = abs.(im[:,:,1,1,1,1]) .- abs.(x)
+  diff .< 1e-10
+  @test (norm(vec(x)-vec(abs.(im[:,:,1,1,1,1])))/norm(vec(x))) < 1e-10
 end
 
 function testGriddingReco3d(N=32)
@@ -430,7 +436,7 @@ function testReco(N=32)
     testSENSEReco(64, ComplexF64)
     !Sys.iswindows() && testOffresonanceSENSEReco()
     testDirectRecoMultiEcho()
-    testRegridding() 
+    testRegridding()
   end
 end
 


### PR DESCRIPTION
in this PR :
- Reconstruction of repetitions along dims=6 (for minimal changes)
- a function to extract the zero-filled cartesian kspace from acquisitionData
- a function to create an acquisitionData from a zero-filled kspace

# Notes
- Should we change order to `x,y,z*slice,channels,echoes,repetitions` ?
- it would be great to be able to set different trajectory for each dimension (not only the echo ones) 

