### PR TITLE
Add optional argument to ESPIRiT to output sensitivity maps of arbitrary size

### DIFF
--- a/src/Simulation/Simulation.jl
+++ b/src/Simulation/Simulation.jl
@@ -112,7 +112,7 @@ function simulation2d(tr::Trajectory{T}, image::Array{Complex{T},3}, correctionM
     nc=1
   else
     if size(senseMaps)[1:3] != (nx,ny,nz)
-      error("senseMaps and image should have the same size!")
+      error("senseMaps and image should have the same size $(size(senseMaps)[1:3]) != $((nx,ny,nz))!")
     end
     sensFac = senseMaps
     nc = size(sensFac,4)

--- a/src/Tools/CoilSensitivity.jl
+++ b/src/Tools/CoilSensitivity.jl
@@ -82,8 +82,8 @@ Obtains coil sensitivities from a calibration area using ESPIRiT. The code is ad
   * `nmaps = 1`                 - Number of maps that are calcualted. Set to 1 for regular SENSE; set to 2 for soft-SENSE (cf. [Uecker et al. "ESPIRiT—an eigenvalue approach to autocalibrating parallel MRI: Where SENSE meets GRAPPA"](https://doi.org/10.1002/mrm.24751)).
   * `use_poweriterations = true` - flag to determine if power iterations are used; power iterations are only used if `nmaps == 1`. They provide speed benefits over the full eigen decomposition, but are an approximation.
 """
-function espirit(acqData::AcquisitionData{T}, ksize::NTuple{2,Int} = (6,6), ncalib::Int = 24, imsize::NTuple{2,Int} = (128,128)
-  ; eigThresh_1::Number = 0.02, eigThresh_2::Number = 0.95, nmaps::Int = 1, use_poweriterations::Bool = true, match_acq_size::Bool = true) where T
+function espirit(acqData::AcquisitionData{T}, ksize::NTuple{2,Int} = (6,6), ncalib::Int = 24, imsize::NTuple{2,Int} = Tuple(acqData.encodingSize[1:2]),
+  ; eigThresh_1::Number = 0.02, eigThresh_2::Number = 0.95, nmaps::Int = 1, use_poweriterations::Bool = true) where T
 
   if !isCartesian(trajectory(acqData, 1))
     @error "espirit does not yet support non-cartesian sampling"
@@ -91,10 +91,10 @@ function espirit(acqData::AcquisitionData{T}, ksize::NTuple{2,Int} = (6,6), ncal
 
   nxAcq, nyAcq = acqData.encodingSize[1:2]
   nx, ny = imsize
+  match_acq_size = all(imsize .== acqData.encodingSize[1:2])
 
-  # match acquisitionData encodingSize if desired. Force maps to be at least same size as acqData.encodingSize.
-  if match_acq_size || (nxAcq >= nx || nyAcq >= ny)
-    match_acq_size = true
+  #  Force maps to be at least same size as acqData.encodingSize.
+  if (nxAcq >= nx || nyAcq >= ny)
     nx, ny = acqData.encodingSize[1:2]
   end  
 

--- a/src/Tools/CoilSensitivity.jl
+++ b/src/Tools/CoilSensitivity.jl
@@ -54,11 +54,13 @@ Obtains coil sensitivities from a calibration area using ESPIRiT. The code is ad
 ## Optional Arguments
 * `ksize::NTuple{2,Int64}`    - size of the k-space kernel; `default = (6,6)`
 * `ncalib::Int64`             - number of calibration points in each dimension; `default = 30`
+* `imsize::NTuple{2,Int}` - size of the output sensitivity maps, cannot be smaller than acqData.encodingSize (enforced); `default = (128,128)`
 
 ## Keyword Arguments
   * `eigThresh_1::Number=0.02`  - threshold for the singular values of the calibration matrix (relative to the largest value); reduce for more accuracy, increase for saving memory and computation time.
   * `eigThresh_2::Number=0.95`  - threshold to mask the final maps: for each voxel, the map will be set to 0, if, for this voxel, no singular value > `eigThresh_2` exists.
   * `nmaps = 1`                 - Number of maps that are calcualted. Set to 1 for regular SENSE; set to 2 for soft-SENSE (cf. [Uecker et al. "ESPIRiT—an eigenvalue approach to autocalibrating parallel MRI: Where SENSE meets GRAPPA"](https://doi.org/10.1002/mrm.24751)).
+  * `match_acq_size = true` - flag to determine if the output sensitivity maps must match the encoding size of the input AcquisitionData
 
 # Method 2
   The second method of this function works with single slice 2D or 3D data; the first argument is the calibration data, i.e. the cropped center of k-space:
@@ -80,22 +82,32 @@ Obtains coil sensitivities from a calibration area using ESPIRiT. The code is ad
   * `nmaps = 1`                 - Number of maps that are calcualted. Set to 1 for regular SENSE; set to 2 for soft-SENSE (cf. [Uecker et al. "ESPIRiT—an eigenvalue approach to autocalibrating parallel MRI: Where SENSE meets GRAPPA"](https://doi.org/10.1002/mrm.24751)).
   * `use_poweriterations = true` - flag to determine if power iterations are used; power iterations are only used if `nmaps == 1`. They provide speed benefits over the full eigen decomposition, but are an approximation.
 """
-function espirit(acqData::AcquisitionData{T}, ksize::NTuple{2,Int} = (6,6), ncalib::Int = 24
-  ; eigThresh_1::Number = 0.02, eigThresh_2::Number = 0.95, nmaps::Int = 1, use_poweriterations::Bool = true) where T
+function espirit(acqData::AcquisitionData{T}, ksize::NTuple{2,Int} = (6,6), ncalib::Int = 24, imsize::NTuple{2,Int} = (128,128)
+  ; eigThresh_1::Number = 0.02, eigThresh_2::Number = 0.95, nmaps::Int = 1, use_poweriterations::Bool = true, match_acq_size::Bool = true) where T
 
   if !isCartesian(trajectory(acqData, 1))
     @error "espirit does not yet support non-cartesian sampling"
   end
 
-  nx, ny = acqData.encodingSize[1:2]
-  numChan, numSl = numChannels(acqData), numSlices(acqData)
-  maps = zeros(Complex{T}, acqData.encodingSize[1], acqData.encodingSize[2], numSl, numChan, nmaps)
+  nxAcq, nyAcq = acqData.encodingSize[1:2]
+  nx, ny = imsize
 
+  # match acquisitionData encodingSize if desired. Force maps to be at least same size as acqData.encodingSize.
+  if match_acq_size || (nxAcq >= nx || nyAcq >= ny)
+    match_acq_size = true
+    nx, ny = acqData.encodingSize[1:2]
+  end  
+
+  numChan, numSl = numChannels(acqData), numSlices(acqData)
+  maps = zeros(Complex{T},nx,ny, numSl, numChan, nmaps)
+
+  idx = match_acq_size ? acqData.subsampleIndices[1] : findIndices((nx,ny),(nxAcq,nyAcq))[acqData.subsampleIndices[1]]
+  
   for slice = 1:numSl
     # form zeropadded array with kspace data
     kdata = zeros(Complex{T}, nx * ny, numChan)
     for coil = 1:numChan
-      kdata[acqData.subsampleIndices[1], coil] .= kData(acqData, 1, coil, slice)
+      kdata[idx, coil] .= kData(acqData, 1, coil, slice)
     end
     kdata = reshape(kdata, nx, ny, numChan)
 
@@ -396,5 +408,24 @@ function estimateCoilSensitivitiesFixedPoint(acqData::AcquisitionData;
   #end
 
 
+
+end
+
+"""
+  findIndices()
+  Calculates the indices which place the center of k-space sampled on oldEnc in the correct place w.r.t a grid of size newEnc
+"""
+function findIndices(newEnc::NTuple{2,Int64},oldEnc::NTuple{2,Int64})
+
+    shiftX=floor((newEnc[1]-oldEnc[1])÷2)
+    shiftY=floor((newEnc[2]-oldEnc[2])÷2)
+    oldCart=CartesianIndices(((shiftX+1):(shiftX+oldEnc[1]),(shiftY+1):(shiftY+oldEnc[2])))
+    newCart=CartesianIndices((1:newEnc[1],1:newEnc[2]))
+
+  if newEnc[1]>oldEnc[1] || newEnc[2]>oldEnc[2]
+    return LinearIndices(newCart)[oldCart][:]
+  else
+    return LinearIndices(oldCart)[:]
+  end
 
 end

--- a/src/Tools/ErrorMeasures.jl
+++ b/src/Tools/ErrorMeasures.jl
@@ -1,4 +1,15 @@
-export nrmsd
+export nrmsd, optimalScalingFactor
+
+
+"""
+    optimalScalingFactor(I,Ireco)
+
+computes the optimal scaling factor α such that || I - α Ireco ||₂ is minimal
+"""
+function optimalScalingFactor(I, Ireco)
+  α = norm(Ireco)>0 ? dot(vec(Ireco),vec(I)) / dot(vec(Ireco),vec(Ireco)) : one(eltype(I))
+  return α
+end
 
 """
     nrmsd(I,Ireco)
@@ -6,14 +17,15 @@ export nrmsd
 computes the normalized root mean squared error of the image `Ireco`
 with respect to the image `I`.
 """
-function nrmsd(I,Ireco)
+function nrmsd(I, Ireco; optimalScaling=true)
   N = length(I)
 
-  # This is a little trick. We usually are not interested in simple scalings
-  # and therefore "calibrate" them away
-  alpha = (dot(vec(I),vec(Ireco))+dot(vec(Ireco),vec(I))) /
-          (2*dot(vec(Ireco),vec(Ireco)))
-  Ireco_ = Ireco * alpha
+  if optimalScaling
+    # This is a little trick. We usually are not interested in simple scalings
+    # and therefore "calibrate" them away
+    α = optimalScalingFactor(I, Ireco)
+    Ireco = α*Ireco
+  end
 
   RMS =  1.0/sqrt(N)*norm(vec(I)-vec(Ireco))
   NRMS = RMS/(maximum(abs.(I))-minimum(abs.(I)) )

--- a/src/Tools/ErrorMeasures.jl
+++ b/src/Tools/ErrorMeasures.jl
@@ -13,7 +13,7 @@ function nrmsd(I,Ireco)
   # and therefore "calibrate" them away
   alpha = (dot(vec(I),vec(Ireco))+dot(vec(Ireco),vec(I))) /
           (2*dot(vec(Ireco),vec(Ireco)))
-  Ireco[:] .*= alpha
+  Ireco_ = Ireco * alpha
 
   RMS =  1.0/sqrt(N)*norm(vec(I)-vec(Ireco))
   NRMS = RMS/(maximum(abs.(I))-minimum(abs.(I)) )

--- a/test/testCoilsens.jl
+++ b/test/testCoilsens.jl
@@ -33,14 +33,16 @@ function testESPIRiT(N=128)
 
   smaps2 = espirit(acqData,ksize,ncalib,eigThresh_1=eigThresh_1,eigThresh_2=eigThresh_2)
 
-  # evaluate error only on the supprt of smaps
+  # evaluate error only on the support of smaps
   for i=1:8
     smaps2[:,:,1,i] = msk .* smaps2[:,:,1,i]
   end
+
   # allow for a constant phase offset
-  phs = mean(angle.(smaps))
-  phs2 = mean(angle.(smaps2))
-  smaps2 = exp(1im*(phs-phs2)) .* smaps2
+  α = optimalScalingFactor(smaps, smaps2)
+  # we don't want to allow scalings in the amplitude
+  α /= abs(α)
+  smaps2 .*= α
 
   err = norm(vec(smaps2)-vec(smaps))/norm(vec(smaps))
   @test err < 3.e-2
@@ -110,6 +112,12 @@ function testESPIRiT_newSize(imsize = 256)
     emaps2[:,:,1,i] = msk2 .* emaps2[:,:,1,i]
     emaps[:,:,1,i] = msk2 .* emaps[:,:,1,i]
   end
+
+  # allow for a constant phase offset
+  α = optimalScalingFactor(emaps, emaps2)
+  # we don't want to allow scalings in the amplitude
+  α /= abs(α)
+  emaps2 .*= α
 
   err = norm(vec(emaps2)-vec(emaps))/norm(vec(emaps))
   @test err < 3.e-2

--- a/test/testCoilsens.jl
+++ b/test/testCoilsens.jl
@@ -1,8 +1,8 @@
 
 
-@testset "ESPIRiT" begin
+function testESPIRiT(N=128)
+
   #image
-  N=128
   img = shepp_logan(N)
   msk = zeros(N,N)
   msk[findall(x->x!=0,img)] .= 1
@@ -44,4 +44,92 @@
 
   err = nrmsd(smaps, smaps2) #norm(vec(smaps2)-vec(smaps))/norm(vec(smaps))
   @test err < 3.e-2
+
+end
+
+
+function testESPIRiT_newSize(imsize = 256)
+
+  #normal image
+  N=imsize÷2
+  img = shepp_logan(N)
+  msk = zeros(N,N)
+  msk[findall(x->x!=0,img)] .= 1
+
+  #larger image
+  img2 = shepp_logan(imsize)
+  msk2 = zeros(imsize,imsize)
+  msk2[findall(x->x!=0,img2)] .= 1
+
+  # coil sensitivites for normal image size
+  smaps = birdcageSensitivity(N, 8, 1.5)
+  snorm = sqrt.(sum(abs.(smaps).^2,dims=4))
+  for i=1:8
+    smaps[:,:,1,i] .= msk .* smaps[:,:,1,i] ./ snorm[:,:,1,1]
+  end
+
+  # coil sensitivites for larger image size
+  smaps2 = birdcageSensitivity(imsize, 8, 1.5)
+  snorm2 = sqrt.(sum(abs.(smaps2).^2,dims=4))
+  for i=1:8
+    smaps2[:,:,1,i] .= msk2 .* smaps2[:,:,1,i] ./ snorm2[:,:,1,1]
+  end
+  
+  # simulation for normal image size
+  params = Dict{Symbol, Any}()
+  params[:simulation] = "fast"
+  params[:trajName] = "Cartesian"
+  params[:numProfiles] = floor(Int64, N)
+  params[:numSamplingPerProfile] = N
+  params[:senseMaps] = smaps
+
+  acqData = simulation(img, params)
+  acqData = MRIReco.sample_kspace(acqData, 2.0, "poisson", calsize=15)
+
+  ksize=(6,6) # kernel size
+  ncalib = 15 # number of calibration lines
+  eigThresh_1 = 0.02  # threshold for picking singular vectors of calibration matrix
+  eigThresh_2 = 0.95  # threshold for eigen vector decomposition in image space
+  match_acq_size = false # use specified image size for the size of the output map
+
+  @time emaps = espirit(acqData,ksize,ncalib,(imsize,imsize),eigThresh_1=eigThresh_1,eigThresh_2=eigThresh_2,match_acq_size = match_acq_size)
+
+  # simulation for larger image size
+  params = Dict{Symbol, Any}()
+  params[:simulation] = "fast"
+  params[:trajName] = "Cartesian"
+  params[:numProfiles] = floor(Int64, imsize)
+  params[:numSamplingPerProfile] = imsize
+  params[:senseMaps] = smaps2
+
+  acqData2 = simulation(img2, params)
+  acqData2 = MRIReco.sample_kspace(acqData2, 2.0, "poisson", calsize=15)
+
+  match_acq_size = true # use nominal image size for size of output map
+
+  @time emaps2 = espirit(acqData2,ksize,ncalib,(imsize,imsize),eigThresh_1=eigThresh_1,eigThresh_2=eigThresh_2,match_acq_size = match_acq_size)
+
+  # evaluate error only on the supprt of smaps
+  for i=1:8
+    emaps2[:,:,1,i] = msk2 .* emaps2[:,:,1,i]
+    emaps[:,:,1,i] = msk2 .* emaps[:,:,1,i]
+  end
+
+  err = nrmsd(emaps, emaps2) #norm(vec(smaps2)-vec(smaps))/norm(vec(smaps))
+  @test err < 3.e-2
+
+end
+
+@testset "ESPIRiT" begin
+
+  # test default ESPIRiT using acqData.encodingSize as output map size
+  testESPIRiT()
+
+  # test making maps of new size from low-res acq data
+  # even matrix size
+  testESPIRiT_newSize(128)
+
+  # odd matrix size
+  testESPIRiT_newSize(127)
+
 end

--- a/test/testCoilsens.jl
+++ b/test/testCoilsens.jl
@@ -31,7 +31,7 @@ function testESPIRiT(N=128)
   eigThresh_1 = 0.02  # threshold for picking singular vectors of calibration matrix
   eigThresh_2 = 0.95  # threshold for eigen vector decomposition in image space
 
-  @time smaps2 = espirit(acqData,ksize,ncalib,eigThresh_1=eigThresh_1,eigThresh_2=eigThresh_2)
+  smaps2 = espirit(acqData,ksize,ncalib,eigThresh_1=eigThresh_1,eigThresh_2=eigThresh_2)
 
   # evaluate error only on the supprt of smaps
   for i=1:8
@@ -42,7 +42,7 @@ function testESPIRiT(N=128)
   phs2 = mean(angle.(smaps2))
   smaps2 = exp(1im*(phs-phs2)) .* smaps2
 
-  err = nrmsd(smaps, smaps2) #norm(vec(smaps2)-vec(smaps))/norm(vec(smaps))
+  err = norm(vec(smaps2)-vec(smaps))/norm(vec(smaps))
   @test err < 3.e-2
 
 end
@@ -90,9 +90,8 @@ function testESPIRiT_newSize(imsize = 256)
   ncalib = 15 # number of calibration lines
   eigThresh_1 = 0.02  # threshold for picking singular vectors of calibration matrix
   eigThresh_2 = 0.95  # threshold for eigen vector decomposition in image space
-  match_acq_size = false # use specified image size for the size of the output map
 
-  @time emaps = espirit(acqData,ksize,ncalib,(imsize,imsize),eigThresh_1=eigThresh_1,eigThresh_2=eigThresh_2,match_acq_size = match_acq_size)
+  emaps = espirit(acqData,ksize,ncalib,(imsize,imsize),eigThresh_1=eigThresh_1,eigThresh_2=eigThresh_2)
 
   # simulation for larger image size
   params = Dict{Symbol, Any}()
@@ -104,20 +103,16 @@ function testESPIRiT_newSize(imsize = 256)
 
   acqData2 = simulation(img2, params)
   acqData2 = MRIReco.sample_kspace(acqData2, 2.0, "poisson", calsize=15)
+  emaps2 = espirit(acqData2,ksize,ncalib,(imsize,imsize),eigThresh_1=eigThresh_1,eigThresh_2=eigThresh_2)
 
-  match_acq_size = true # use nominal image size for size of output map
-
-  @time emaps2 = espirit(acqData2,ksize,ncalib,(imsize,imsize),eigThresh_1=eigThresh_1,eigThresh_2=eigThresh_2,match_acq_size = match_acq_size)
-
-  # evaluate error only on the supprt of smaps
+  # evaluate error only on the support of smaps
   for i=1:8
     emaps2[:,:,1,i] = msk2 .* emaps2[:,:,1,i]
     emaps[:,:,1,i] = msk2 .* emaps[:,:,1,i]
   end
 
-  err = nrmsd(emaps, emaps2) #norm(vec(smaps2)-vec(smaps))/norm(vec(smaps))
+  err = norm(vec(emaps2)-vec(emaps))/norm(vec(emaps))
   @test err < 3.e-2
-
 end
 
 @testset "ESPIRiT" begin


### PR DESCRIPTION
Added functionality to `espirit` enabling sensitivity maps estimated at arbitrary sizes by zero padding low resolution k-space data, as mentioned in the meeting. There is possibly a more elegant way of doing this, but this seems to work. Tests pass both in the original ESPIRiT test (which I've made into a function) and the new tests I've added which test that the same maps are produced from nominal resolution acqData and lower resolution acqData.