### PR TITLE
reshape hack so that ESPIRIT is compatible with the MKL backend of FFTW

### DIFF
--- a/src/Tools/CoilSensitivity.jl
+++ b/src/Tools/CoilSensitivity.jl
@@ -204,13 +204,14 @@ function kernelEig(kernel::Array{T}, imsize::Tuple, nmaps=1; use_poweriterations
       end
     end
   end
-  fft!(kern2_, 3:ndims(kern2_))
+  # resize is neccessary for compatibility with MKL
+  reshape(fft!(reshape(kern2_, nc^2, sizePadded...), 2:ndims(kern2_)-1), nc, nc, sizePadded...)
 
   kern2 = zeros(T, nc, nc, imsize...)
   idx_center = CartesianIndices(sizePadded) .- CartesianIndex(sizePadded .÷ 2) .+ CartesianIndex(imsize .÷ 2)
   @views ifftshift!(kern2[:,:,idx_center], kern2_, 3:ndims(kern2_))
 
-  ifft!(kern2, 3:ndims(kern2))
+  reshape(ifft!(reshape(kern2, nc^2, imsize...), 2:ndims(kern2)-1), nc, nc, imsize...)
   kern2 .*= prod(imsize) / prod(sizePadded) / prod(ksize)
 
 


### PR DESCRIPTION
Hi, 
it seems that FFTW with the MKL backend does not support calls like `fft!(x, 3:ndims(x))`:
https://github.com/JuliaMath/FFTW.jl/issues/252

I implemented a hack to circumvent this problem by doing a reshape and then calling `fft!(x, 2:ndims(x)-1)`. If found virtually no speed regression when using the FFTW backend and, well, no error when using the MKL backend ;). (I tested it speed wise with the small example in the test and replace `@time` with `@btime` for reliable benchmarking. 