### PR TITLE
Make minimal header of Raw consistent with Acq Data encoding size + type check for ISMRMRD encodedFOV

### DIFF
--- a/MRIBase/src/Datatypes/RawAcqData.jl
+++ b/MRIBase/src/Datatypes/RawAcqData.jl
@@ -294,7 +294,7 @@ function AcquisitionData(f::RawAcquisitionData; estimateProfileCenter::Bool=fals
   acq = AcquisitionData(tr, kdata,
                           idx = subsampleIdx,
                           encodingSize = ntuple(d->f.params["encodedSize"][d], ndims(tr[1])),
-                          fov = ntuple(d->f.params["encodedFOV"][d], 3) )
+                          fov = Float64.(ntuple(d->f.params["encodedFOV"][d], 3)))
 
   if OffsetBruker
     ROT = [[f.profiles[1].head.read_dir...] [f.profiles[1].head.phase_dir...] [f.profiles[1].head.slice_dir...]]
@@ -311,9 +311,9 @@ end
 
 converts `acqData` into the equivalent `RawAcquisitionData` object.
 """
-function RawAcquisitionData(acqData::AcquisitionData)
+function RawAcquisitionData(acqData::AcquisitionData{T,D}) where {T,D}
   # XML header
-  params = minimalHeader(ntuple(d->acqData.encodingSize[d],3), acqData.fov, tr_name=string(trajectory(acqData,1)))
+  params = minimalHeader(ntuple(d->acqData.encodingSize[d],D), T.(acqData.fov), tr_name=string(trajectory(acqData,1)))
   # acquisition counter
   counter = 1
   # profiles
@@ -396,7 +396,7 @@ function uniqueidx(x::Matrix{T}) where T
   idxs
 end
 
-function minimalHeader(encodingSize::NTuple{3,Int}, fov::NTuple{3,AbstractFloat};
+function minimalHeader(encodingSize, fov::NTuple{3,AbstractFloat};
                       f_res::Integer=1, tr_name::AbstractString="cartesian", numChannels::Int=1)
 
   params = Dict{String,Any}()


### PR DESCRIPTION
I noticed that sometimes the `encodedFOV` in the ISMRMRD files is written in a way that gets automatically interpreted by MRIReco as an Integer tuple when creating RawAcquisitionData. This is then incompatible with the AcquisitionData constructor which requires the FOV to be of type `NTuple{3,Float64}`. I added a small type conversion for this. Also, the minimal header of the raw data when producing RawAcquisitionData from AcquisitionData should be consistent with the dimensions of the AcquisitionData. 