### PR TITLE
raw.encodedFOV in mm and acq.fov in meter

### DIFF
--- a/MRIBase/src/Datatypes/AcqData.jl
+++ b/MRIBase/src/Datatypes/AcqData.jl
@@ -15,7 +15,7 @@ struct describing MRI acquisition data.
                                               1. dim echoes, 2. dim slices, 3. dim repetitions
 * `subsampleIndices::Vector{Array{Int64}}`  - indices sampled for each echo/contrast
 * `encodingSize::Vector{Int64}`             - size of the underlying image matrix
-* `fov::Vector{Float64}`                    - field of view in m
+* `fov::Vector{Float64}`                    - field of view in mm
 """
 mutable struct AcquisitionData{T <: AbstractFloat, D}
   sequenceInfo::Dict{Symbol,Any}

--- a/MRIBase/src/Datatypes/RawAcqData.jl
+++ b/MRIBase/src/Datatypes/RawAcqData.jl
@@ -294,7 +294,7 @@ function AcquisitionData(f::RawAcquisitionData; estimateProfileCenter::Bool=fals
   acq = AcquisitionData(tr, kdata,
                           idx = subsampleIdx,
                           encodingSize = ntuple(d->f.params["encodedSize"][d], ndims(tr[1])),
-                          fov = Float64.(ntuple(d->f.params["encodedFOV"][d]/1000.0, 3)))
+                          fov = Float64.(ntuple(d->f.params["encodedFOV"][d], 3)))
 
   if OffsetBruker
     ROT = [[f.profiles[1].head.read_dir...] [f.profiles[1].head.phase_dir...] [f.profiles[1].head.slice_dir...]]
@@ -313,7 +313,7 @@ converts `acqData` into the equivalent `RawAcquisitionData` object.
 """
 function RawAcquisitionData(acqData::AcquisitionData{T,D}) where {T,D}
   # XML header
-  params = minimalHeader(ntuple(d->acqData.encodingSize[d],D), T.(acqData.fov) .* 1000.0, tr_name=string(trajectory(acqData,1)))
+  params = minimalHeader(ntuple(d->acqData.encodingSize[d],D), T.(acqData.fov), tr_name=string(trajectory(acqData,1)))
   # acquisition counter
   counter = 1
   # profiles

--- a/MRIBase/src/Datatypes/RawAcqData.jl
+++ b/MRIBase/src/Datatypes/RawAcqData.jl
@@ -243,7 +243,7 @@ function rawdata(f::RawAcquisitionData; slice::Int=1, contrast::Int=1, repetitio
   # assume the same number of samples for all profiles
   numSampPerProfile, numChan = size(f.profiles[idx[1]].data)
   numSampPerProfile -= (f.profiles[idx[1]].head.discard_pre+f.profiles[idx[1]].head.discard_post)
-  
+
   if f.params["trajectory"] == "custom"
     numProf = Int(length(f.profiles)/(numSl * numRep * numContr))
     kdata = zeros(typeof(f.profiles[1].data[1, 1]), numSampPerProfile, numProf, numChan)
@@ -264,7 +264,7 @@ function rawdata(f::RawAcquisitionData; slice::Int=1, contrast::Int=1, repetitio
     kdata[:,cnt,:] .= f.profiles[l].data[i1:i2, :]
     cnt += 1
   end
-  
+
   return reshape(kdata, :, numChan)
 end
 
@@ -272,7 +272,7 @@ end
 """
     AcquisitionData(f::RawAcquisitionData; estimateProfileCenter::Bool=false, OffsetBruker=false)
 
-converts `RawAcquisitionData` into the equivalent `AcquisitionData` object. 
+converts `RawAcquisitionData` into the equivalent `AcquisitionData` object.
 If OffsetBruker=true, add a phase offset to correct position only along Y/Z direction
 """
 function AcquisitionData(f::RawAcquisitionData; estimateProfileCenter::Bool=false, OffsetBruker=false)
@@ -286,7 +286,7 @@ function AcquisitionData(f::RawAcquisitionData; estimateProfileCenter::Bool=fals
   # subsampleIdx = [subsampleIndices(f,contrast=contr,estimateProfileCenter=estimateProfileCenter) for contr=1:numContr]
   # kdata = [rawdata(f; contrast=i, slice=j, repetition=k) for i=1:numContr, j=1:numSl, k=1:numRep]
 
-  
+
   tr = [trajectory(f,contrast=contr) for contr=contrs]
   subsampleIdx = [subsampleIndices(f,contrast=contr,estimateProfileCenter=estimateProfileCenter) for contr=contrs]
   kdata = [rawdata(f; contrast=i, slice=j, repetition=k) for i=contrs, j=sls, k=reps]
@@ -294,7 +294,7 @@ function AcquisitionData(f::RawAcquisitionData; estimateProfileCenter::Bool=fals
   acq = AcquisitionData(tr, kdata,
                           idx = subsampleIdx,
                           encodingSize = ntuple(d->f.params["encodedSize"][d], ndims(tr[1])),
-                          fov = Float64.(ntuple(d->f.params["encodedFOV"][d], 3)))
+                          fov = Float64.(ntuple(d->f.params["encodedFOV"][d]/1000.0, 3)))
 
   if OffsetBruker
     ROT = [[f.profiles[1].head.read_dir...] [f.profiles[1].head.phase_dir...] [f.profiles[1].head.slice_dir...]]
@@ -313,7 +313,7 @@ converts `acqData` into the equivalent `RawAcquisitionData` object.
 """
 function RawAcquisitionData(acqData::AcquisitionData{T,D}) where {T,D}
   # XML header
-  params = minimalHeader(ntuple(d->acqData.encodingSize[d],D), T.(acqData.fov), tr_name=string(trajectory(acqData,1)))
+  params = minimalHeader(ntuple(d->acqData.encodingSize[d],D), T.(acqData.fov) .* 1000.0, tr_name=string(trajectory(acqData,1)))
   # acquisition counter
   counter = 1
   # profiles

--- a/MRIFiles/src/Bruker/Bruker.jl
+++ b/MRIFiles/src/Bruker/Bruker.jl
@@ -117,11 +117,11 @@ function acqSize(b::BrukerFile)
   return N
 end
 function acqFov(b::BrukerFile)
-  N = parse.(Float64,b["ACQ_fov"])./100
+  N = parse.(Float64,b["ACQ_fov"]) .* 10 #cm to mm
   if length(N) == 3
     return N
   else
-    return push!(N, parse(Float64,b["ACQ_slice_sepn"][1])./100)
+    return push!(N, parse(Float64,b["ACQ_slice_sepn"][1]) .* 10) #cm to mm
   end
 end
 ##$PVM_EncAvailReceivers=1


### PR DESCRIPTION
## Issue 
`raw.params["encodedFOV"]` is currently in meter when I read a BrukerFile and it is in mm for read_dir... which cause some issue later when I want to correct the offset.
According to this, I think encodedFOV should be in mm ? https://github.com/ismrmrd/ismrmrd/blob/1b260407a69195a6666844e9706ff20ba965ef29/schema/ismrmrd_example.xml#L26

But for `AcquisitionData` : 
```
* `fov::Vector{Float64}`                    - field of view in m
```

## This PR corrects : 
- the fov units for bruker datasets. 
- convert the units from mm to meter during AcquisitionData(raw::RawAcquisitionData)


## discusion

Should we put fov in mm for AcquisitionData ?

What functions are using acq.fov ?
- nifti exports
