### PR TITLE
Noise decorrelation implementation for multiCoilMultiEcho reconstruction

### DIFF
--- a/src/Reconstruction/IterativeReconstruction.jl
+++ b/src/Reconstruction/IterativeReconstruction.jl
@@ -260,7 +260,7 @@ function reconstruction_multiCoilMultiEcho(acqData::AcquisitionData{T}
     if encodingOps != nothing
       E = encodingOps[i]
     else
-      E = encodingOp_multiEcho_parallel(acqData, reconSize, senseMaps; slice=i, encParams...)
+      E = encodingOp_multiEcho_parallel(acqData, reconSize, senseMapsUnCorr; slice=i, encParams...)
     end
 
     kdata = multiCoilMultiEchoData(acqData, i) .* repeat(vcat(weights...), numChan)

--- a/src/Reconstruction/RecoParameters.jl
+++ b/src/Reconstruction/RecoParameters.jl
@@ -128,7 +128,8 @@ function setupIterativeReco(acqData::AcquisitionData{T}, recoParams::Dict) where
   if isempty(noiseData)
     L_inv = nothing
   else
-    L = cholesky(covariance(noiseData), check = true)
+    psi = convert(typeof(noiseData), covariance(noiseData))
+    L = cholesky(psi, check = true)
     L_inv = inv(L.L) #noise decorrelation matrix
   end
 

--- a/src/Reconstruction/Reconstruction.jl
+++ b/src/Reconstruction/Reconstruction.jl
@@ -46,7 +46,7 @@ function reconstruction(acqData::AcquisitionData, recoParams::Dict)
     elseif recoParams[:reco] == "multiCoil"
         return reconstruction_multiCoil(acqData, reconSize[1:encodingDims], reg, sparseTrafo, weights, L_inv, solvername, senseMaps, normalize, encOps, recoParams)
     elseif recoParams[:reco] == "multiCoilMultiEcho"
-        return reconstruction_multiCoilMultiEcho(acqData, reconSize[1:encodingDims], reg, sparseTrafo, weights, solvername, senseMaps, normalize, encOps, recoParams)
+        return reconstruction_multiCoilMultiEcho(acqData, reconSize[1:encodingDims], reg, sparseTrafo, weights, L_inv, solvername, senseMaps, normalize, encOps, recoParams)
     else
         @error "reco modell $(recoParams[:reco]) not found"
     end


### PR DESCRIPTION
Following discussion #135 and pull request #140 I have implemented the noise decorrelation in the multiCoilMultiEcho reconstruction. However, as far as I can tell there are no tests implemented for this reconstruction and when I try to run it on my data I get an error, so I was not able to test it. It seems like the function multiCoilMultiEchoData in the file AcqData.jl should be exported to make the reconstruction work. I assume there is a reason why this function was not exported, so I am not sure how to proceed. I also have very little time to dedicate to this in the near future, so it would be great if someone else could write a test for this function.