### PR TITLE
Fix sensitivity op

### DIFF
--- a/MRIOperators/src/EncodingOp.jl
+++ b/MRIOperators/src/EncodingOp.jl
@@ -1,4 +1,4 @@
-export EncodingOp, lrEncodingOp, fourierEncodingOp, encodingOps_simple, 
+export EncodingOp, lrEncodingOp, fourierEncodingOp, encodingOps_simple,
        encodingOps_parallel, encodingOp_multiEcho, encodingOp_multiEcho_parallel
 
 """
@@ -16,7 +16,7 @@ function encodingOps_simple(acqData::AcquisitionData{T,D}, shape::NTuple{D,Int64
   numContr = numContrasts(acqData)
   tr = [trajectory(acqData,i) for i=1:numContr]
   idx = acqData.subsampleIndices
-  return [fourierEncodingOp(shape, tr[i], "fast", 
+  return [fourierEncodingOp(shape, tr[i], "fast",
                  subsampleIdx=idx[i]; kargs...) for i=1:numContr]
 end
 
@@ -44,7 +44,7 @@ function encodingOps_parallel(acqData::AcquisitionData{T,D}, shape::NTuple{D,Int
   # fourier operators
   ft = encodingOps_simple(acqData, shape; slice=slice, kargs...)
   S = SensitivityOp(reshape(smaps,:,numChan),1)
-  Op = [ diagOp(ft[i], numChan) ∘ S for i=1:numContr]
+  Op = [ DiagOp(ft[i], numChan) ∘ S for i=1:numContr]
 
   return Op
 end
@@ -63,7 +63,7 @@ function encodingOp_multiEcho(acqData::AcquisitionData{T,D}, shape::NTuple{D,Int
                                 ; kargs...) where {T,D}
   # fourier operators
   ft = encodingOps_simple(acqData, shape; kargs...)
-  return diagOp(ft...)
+  return DiagOp(ft...)
 end
 
 """
@@ -89,8 +89,8 @@ function encodingOp_multiEcho_parallel(acqData::AcquisitionData{T,D}, shape::NTu
   numChan = numChannels(acqData)
   # fourier operators
   ft = encodingOps_simple(acqData, shape; kargs...)
-  S = SensitivityOp(reshape(smaps,:,numChan),numContrasts(acqData)) 
-  return diagOp(repeat(ft, outer=numChan)...) ∘ S
+  S = SensitivityOp(reshape(smaps,:,numChan),numContrasts(acqData))
+  return DiagOp(repeat(ft, outer=numChan)...) ∘ S
 end
 
 ###################################
@@ -112,9 +112,9 @@ function lrEncodingOp(acqData::AcquisitionData, shape, params::Dict; numContr::I
   # coil sensitivities in case of SENSE-reconstruction
   if parallel
     S = SensitivityOp(params[:senseMaps][:,:],K)
-    E = diagOp( [ft for i=1:numChan*K]... )*S
+    E = DiagOp( [ft for i=1:numChan*K]... )*S
   else
-    E = diagOp( [ft for i=1:K]... )
+    E = DiagOp( [ft for i=1:K]... )
   end
 
   #  TODO: sampling operator in case of undersampled cartesian acquisitions

--- a/MRIOperators/src/MRIOperators.jl
+++ b/MRIOperators/src/MRIOperators.jl
@@ -50,21 +50,21 @@ function vcat(A::AbstractLinearOperator, n::Int)
   return op
 end
 
-function DiagOpProd(y::AbstractVector{T}, x::AbstractVector{T}, nrow::Int, xIdx, yIdx, ops :: AbstractLinearOperator...) where T
+function diagOpProd(y::AbstractVector{T}, x::AbstractVector{T}, nrow::Int, xIdx, yIdx, ops :: AbstractLinearOperator...) where T
   @floop for i=1:length(ops)
     mul!(view(y,yIdx[i]:yIdx[i+1]-1), ops[i], view(x,xIdx[i]:xIdx[i+1]-1))
   end
   return y
 end
 
-function DiagOpTProd(y::AbstractVector{T}, x::AbstractVector{T}, ncol::Int, xIdx, yIdx, ops :: AbstractLinearOperator...) where T
+function diagOpTProd(y::AbstractVector{T}, x::AbstractVector{T}, ncol::Int, xIdx, yIdx, ops :: AbstractLinearOperator...) where T
   @floop for i=1:length(ops)
     mul!(view(y,yIdx[i]:yIdx[i+1]-1), transpose(ops[i]), view(x,xIdx[i]:xIdx[i+1]-1))
   end
   return y
 end
 
-function DiagOpCTProd(y::AbstractVector{T}, x::AbstractVector{T}, ncol::Int, xIdx, yIdx, ops :: AbstractLinearOperator...) where T
+function diagOpCTProd(y::AbstractVector{T}, x::AbstractVector{T}, ncol::Int, xIdx, yIdx, ops :: AbstractLinearOperator...) where T
   @floop for i=1:length(ops)
     mul!(view(y,yIdx[i]:yIdx[i+1]-1), adjoint(ops[i]), view(x,xIdx[i]:xIdx[i+1]-1))
   end
@@ -120,9 +120,9 @@ function DiagOp(ops :: AbstractLinearOperator...)
   yIdx = cumsum(vcat(1,[ops[i].nrow for i=1:length(ops)]))
 
   Op = DiagOp{S}( nrow, ncol, false, false,
-                     (res,x) -> (DiagOpProd(res,x,nrow,xIdx,yIdx,ops...)),
-                     (res,y) -> (DiagOpTProd(res,y,ncol,yIdx,xIdx,ops...)),
-                     (res,y) -> (DiagOpCTProd(res,y,ncol,yIdx,xIdx,ops...)),
+                     (res,x) -> (diagOpProd(res,x,nrow,xIdx,yIdx,ops...)),
+                     (res,y) -> (diagOpTProd(res,y,ncol,yIdx,xIdx,ops...)),
+                     (res,y) -> (diagOpCTProd(res,y,ncol,yIdx,xIdx,ops...)),
                      0, 0, 0, false, false, false, S[], S[],
                      [ops...], false, xIdx, yIdx)
 
@@ -139,9 +139,9 @@ function DiagOp(op::AbstractLinearOperator, N=1)
   yIdx = cumsum(vcat(1,[ops[i].nrow for i=1:length(ops)]))
 
   Op = DiagOp{S}( nrow, ncol, false, false,
-                    (res,x) -> (DiagOpProd(res,x,nrow,xIdx,yIdx,ops...)),
-                    (res,y) -> (DiagOpTProd(res,y,ncol,yIdx,xIdx,ops...)),
-                    (res,y) -> (DiagOpCTProd(res,y,ncol,yIdx,xIdx,ops...)),
+                    (res,x) -> (diagOpProd(res,x,nrow,xIdx,yIdx,ops...)),
+                    (res,y) -> (diagOpTProd(res,y,ncol,yIdx,xIdx,ops...)),
+                    (res,y) -> (diagOpCTProd(res,y,ncol,yIdx,xIdx,ops...)),
                      0, 0, 0, false, false, false, S[], S[],
                      ops, true, xIdx, yIdx )
 

--- a/MRIOperators/src/MRIOperators.jl
+++ b/MRIOperators/src/MRIOperators.jl
@@ -1,7 +1,7 @@
 module MRIOperators
 
 import Base: hcat, vcat, \
-export hcat, vcat, \, diagOp
+export hcat, vcat, \, DiagOp
 
 using Reexport
 using MRIBase
@@ -50,21 +50,21 @@ function vcat(A::AbstractLinearOperator, n::Int)
   return op
 end
 
-function diagOpProd(y::AbstractVector{T}, x::AbstractVector{T}, nrow::Int, xIdx, yIdx, ops :: AbstractLinearOperator...) where T
+function DiagOpProd(y::AbstractVector{T}, x::AbstractVector{T}, nrow::Int, xIdx, yIdx, ops :: AbstractLinearOperator...) where T
   @floop for i=1:length(ops)
     mul!(view(y,yIdx[i]:yIdx[i+1]-1), ops[i], view(x,xIdx[i]:xIdx[i+1]-1))
   end
   return y
 end
 
-function diagOpTProd(y::AbstractVector{T}, x::AbstractVector{T}, ncol::Int, xIdx, yIdx, ops :: AbstractLinearOperator...) where T
+function DiagOpTProd(y::AbstractVector{T}, x::AbstractVector{T}, ncol::Int, xIdx, yIdx, ops :: AbstractLinearOperator...) where T
   @floop for i=1:length(ops)
     mul!(view(y,yIdx[i]:yIdx[i+1]-1), transpose(ops[i]), view(x,xIdx[i]:xIdx[i+1]-1))
   end
   return y
 end
 
-function diagOpCTProd(y::AbstractVector{T}, x::AbstractVector{T}, ncol::Int, xIdx, yIdx, ops :: AbstractLinearOperator...) where T
+function DiagOpCTProd(y::AbstractVector{T}, x::AbstractVector{T}, ncol::Int, xIdx, yIdx, ops :: AbstractLinearOperator...) where T
   @floop for i=1:length(ops)
     mul!(view(y,yIdx[i]:yIdx[i+1]-1), adjoint(ops[i]), view(x,xIdx[i]:xIdx[i+1]-1))
   end
@@ -102,11 +102,11 @@ LinearOperators.storage_type(op::DiagOp) = typeof(op.Mv5)
 
 
 """
-    diagOp(ops :: AbstractLinearOperator...)
+    DiagOp(ops :: AbstractLinearOperator...)
 
 create a bloc-diagonal operator out of the `LinearOperator`s contained in ops
 """
-function diagOp(ops :: AbstractLinearOperator...)
+function DiagOp(ops :: AbstractLinearOperator...)
   nrow = 0
   ncol = 0
   S = eltype(ops[1])
@@ -120,16 +120,16 @@ function diagOp(ops :: AbstractLinearOperator...)
   yIdx = cumsum(vcat(1,[ops[i].nrow for i=1:length(ops)]))
 
   Op = DiagOp{S}( nrow, ncol, false, false,
-                     (res,x) -> (diagOpProd(res,x,nrow,xIdx,yIdx,ops...)),
-                     (res,y) -> (diagOpTProd(res,y,ncol,yIdx,xIdx,ops...)),
-                     (res,y) -> (diagOpCTProd(res,y,ncol,yIdx,xIdx,ops...)),
+                     (res,x) -> (DiagOpProd(res,x,nrow,xIdx,yIdx,ops...)),
+                     (res,y) -> (DiagOpTProd(res,y,ncol,yIdx,xIdx,ops...)),
+                     (res,y) -> (DiagOpCTProd(res,y,ncol,yIdx,xIdx,ops...)),
                      0, 0, 0, false, false, false, S[], S[],
                      [ops...], false, xIdx, yIdx)
 
   return Op
 end
 
-function diagOp(op::AbstractLinearOperator, N=1)
+function DiagOp(op::AbstractLinearOperator, N=1)
   nrow = N*op.nrow
   ncol = N*op.ncol
   S = eltype(op)
@@ -139,9 +139,9 @@ function diagOp(op::AbstractLinearOperator, N=1)
   yIdx = cumsum(vcat(1,[ops[i].nrow for i=1:length(ops)]))
 
   Op = DiagOp{S}( nrow, ncol, false, false,
-                    (res,x) -> (diagOpProd(res,x,nrow,xIdx,yIdx,ops...)),
-                    (res,y) -> (diagOpTProd(res,y,ncol,yIdx,xIdx,ops...)),
-                    (res,y) -> (diagOpCTProd(res,y,ncol,yIdx,xIdx,ops...)),
+                    (res,x) -> (DiagOpProd(res,x,nrow,xIdx,yIdx,ops...)),
+                    (res,y) -> (DiagOpTProd(res,y,ncol,yIdx,xIdx,ops...)),
+                    (res,y) -> (DiagOpCTProd(res,y,ncol,yIdx,xIdx,ops...)),
                      0, 0, 0, false, false, false, S[], S[],
                      ops, true, xIdx, yIdx )
 

--- a/MRIOperators/src/MRIOperators.jl
+++ b/MRIOperators/src/MRIOperators.jl
@@ -98,6 +98,9 @@ mutable struct DiagOp{T} <: AbstractLinearOperator{T}
 end
 
 
+LinearOperators.storage_type(op::DiagOp) = typeof(op.Mv5)
+
+
 """
     diagOp(ops :: AbstractLinearOperator...)
 
@@ -119,7 +122,7 @@ function diagOp(ops :: AbstractLinearOperator...)
   Op = DiagOp{S}( nrow, ncol, false, false,
                      (res,x) -> (diagOpProd(res,x,nrow,xIdx,yIdx,ops...)),
                      (res,y) -> (diagOpTProd(res,y,ncol,yIdx,xIdx,ops...)),
-                     (res,y) -> (diagOpCTProd(res,y,ncol,yIdx,xIdx,ops...)), 
+                     (res,y) -> (diagOpCTProd(res,y,ncol,yIdx,xIdx,ops...)),
                      0, 0, 0, false, false, false, S[], S[],
                      [ops...], false, xIdx, yIdx)
 
@@ -138,7 +141,7 @@ function diagOp(op::AbstractLinearOperator, N=1)
   Op = DiagOp{S}( nrow, ncol, false, false,
                     (res,x) -> (diagOpProd(res,x,nrow,xIdx,yIdx,ops...)),
                     (res,y) -> (diagOpTProd(res,y,ncol,yIdx,xIdx,ops...)),
-                    (res,y) -> (diagOpCTProd(res,y,ncol,yIdx,xIdx,ops...)), 
+                    (res,y) -> (diagOpCTProd(res,y,ncol,yIdx,xIdx,ops...)),
                      0, 0, 0, false, false, false, S[], S[],
                      ops, true, xIdx, yIdx )
 
@@ -171,13 +174,13 @@ end
 LinearOperators.storage_type(op::DiagNormalOp) = typeof(op.Mv5)
 
 function DiagNormalOp(normalOps, N, idx, y::Vector{T}) where {T}
-  
+
   function produ!(y, normalOps, idx, x)
     @floop for i=1:length(normalOps)
        mul!(view(y,idx[i]:idx[i+1]-1), normalOps[i], view(x,idx[i]:idx[i+1]-1))
     end
     return y
-  end  
+  end
 
   return DiagNormalOp(N, N, false, false
          , (res,x) -> produ!(res, normalOps, idx, x)

--- a/MRIOperators/src/SensitivityOp.jl
+++ b/MRIOperators/src/SensitivityOp.jl
@@ -4,7 +4,7 @@ function prod_smap!(y::AbstractVector{T}, smaps::AbstractMatrix{T}, x::AbstractV
   x_ = reshape(x,numVox,numContr)
   y_ = reshape(y,numVox,numContr,numChan)
 
-  @assert size(smaps) == size(y_)[1,3]
+  @assert size(smaps) == (size(y_,1), size(y_,3))
 
   @inbounds for i ∈ CartesianIndices(y_)
     y_[i] = x_[i[1],i[2]] * smaps[i[1],i[3]]
@@ -16,7 +16,7 @@ function ctprod_smap!(y::AbstractVector{T}, smapsC::AbstractMatrix{T}, x::Abstra
   x_ = reshape(x,numVox,numContr,numChan)
   y_ = reshape(y,numVox,numContr)
 
-  @assert size(smapsC) == size(x_)[1,3]
+  @assert size(smapsC) == (size(x_,1), size(x_,3))
 
   y_ .= 0
   @inbounds for i ∈ CartesianIndices(x_)

--- a/MRIOperators/src/SensitivityOp.jl
+++ b/MRIOperators/src/SensitivityOp.jl
@@ -1,40 +1,41 @@
-function prod_smap!(y::Vector{T}, smaps::Matrix{T}, x::Vector{T}, numVox::Int64, numChan::Int64, numContr::Int=1) where T
-    x = reshape(x,numVox,numContr)
-    y_ = reshape(y,numVox,numContr,numChan)
-    @inbounds for j=1:numChan
-        @inbounds for i=1:numContr
-          @inbounds for k=1:numVox
-            y_[k,i,j] = x[k,i] * smaps[k,j]
-          end
-        end
-    end
-    return y
+export SensitivityOp
+
+function prod_smap!(y::AbstractVector{T}, smaps::AbstractMatrix{T}, x::AbstractVector{T}, numVox, numChan, numContr=1) where T
+  x_ = reshape(x,numVox,numContr)
+  y_ = reshape(y,numVox,numContr,numChan)
+
+  @assert size(smaps) == size(y_)[1,3]
+
+  @inbounds for i ∈ CartesianIndices(y_)
+    y_[i] = x_[i[1],i[2]] * smaps[i[1],i[3]]
+  end
+  return y
 end
 
-function ctprod_smap!(y::Vector{T}, smapsC::Matrix{T}, x::Vector{T}, numVox::Int64, numChan::Int64, numContr::Int=1) where T
-    x = reshape(x,numVox,numContr,numChan)
-    y_ = reshape(y,numVox,numContr)
-    y_ .= 0
-    @inbounds for j=1:numChan
-      @inbounds for i=1:numContr
-        @inbounds for k=1:numVox
-          y_[k,i] += x[k,i,j] * smapsC[k,j]
-        end
-      end
+function ctprod_smap!(y::AbstractVector{T}, smapsC::AbstractMatrix{T}, x::AbstractVector{T}, numVox, numChan, numContr=1) where T
+  x_ = reshape(x,numVox,numContr,numChan)
+  y_ = reshape(y,numVox,numContr)
+
+  @assert size(smapsC) == size(x_)[1,3]
+
+  y_ .= 0
+  @inbounds for i ∈ CartesianIndices(x_)
+    y_[i[1],i[2]] += x_[i] * smapsC[i[1],i[3]]
   end
   return y
 end
 
 
 """
-    SensitivityOp(sensMaps::Matrix{ComplexF64}, numEchoes::Int=1)
+  SensitivityOp(sensMaps::AbstractMatrix{T}, numContr=1)
+
 builds a `LinearOperator` which performs multiplication of a given image with
 the coil sensitivities specified in `sensMaps`
 # Arguments
-* `sensMaps::Matrix{ComplexF64}`  - sensitivity maps ( 1. dim -> voxels, 2. dim-> coils)
-* `numEchoes`                     - number of contrasts to which the operator will be applied
+* `sensMaps`    - sensitivity maps ( 1. dim -> voxels, 2. dim-> coils)
+* `numEchoes`   - number of contrasts to which the operator will be applied
 """
-function SensitivityOp(sensMaps::Matrix{T}, numContr::Int=1) where T
+function SensitivityOp(sensMaps::AbstractMatrix{T}, numContr=1) where T
     numVox, numChan = size(sensMaps)
     sensMapsC = conj.(sensMaps)
     return LinearOperator{T}(numVox*numContr*numChan, numVox*numContr, false, false,
@@ -44,14 +45,15 @@ function SensitivityOp(sensMaps::Matrix{T}, numContr::Int=1) where T
 end
 
 """
-    SensitivityOp(sensMaps::Array{T,4}, numContr::Int=1) where T
+  SensitivityOp(sensMaps::AbstractArray{T,4}, numContr=1)
+
 builds a `LinearOperator` which performs multiplication of a given image with
 the coil sensitivities specified in `sensMaps`
 # Arguments
-* `sensMaps::Array{T,4}`  - sensitivity maps ( 1.-3. dim -> voxels, 4. dim-> coils)
-* `numContr`             - number of contrasts to which the operator will be applied
+* `sensMaps`  - sensitivity maps ( 1.-3. dim -> voxels, 4. dim-> coils)
+* `numContr`  - number of contrasts to which the operator will be applied
 """
-function SensitivityOp(sensMaps::Array{T,4}, numContr::Int=1) where T #{T,D}
+function SensitivityOp(sensMaps::AbstractArray{T,4}, numContr=1) where T #{T,D}
   sensMaps_mat = reshape(sensMaps, div(length(sensMaps),size(sensMaps,4)),size(sensMaps,4))
   return SensitivityOp(sensMaps_mat, numContr)
 end

--- a/src/Reconstruction/IterativeReconstruction.jl
+++ b/src/Reconstruction/IterativeReconstruction.jl
@@ -38,7 +38,7 @@ function reconstruction_simple( acqData::AcquisitionData{T}
 
   # reconstruction
   Ireco = zeros(Complex{T}, prod(reconSize), numSl, numContr, numChan, numRep)
-  #@floop 
+  #@floop
   for l = 1:numRep, k = 1:numSl
     if encodingOps!=nothing
       F = encodingOps[:,k]
@@ -101,7 +101,7 @@ function reconstruction_multiEcho(acqData::AcquisitionData{Complex{T}}
   encParams = getEncodingOperatorParams(;params...)
 
   # set sparse trafo in reg
-  reg[1].params[:sparseTrafo] = diagOp( repeat([sparseTrafo],numContr)... )
+  reg[1].params[:sparseTrafo] = DiagOp( repeat([sparseTrafo],numContr)... )
 
   W = WeightingOp( vcat(weights...) )
 
@@ -247,7 +247,7 @@ function reconstruction_multiCoilMultiEcho(acqData::AcquisitionData{T}
   encParams = getEncodingOperatorParams(;params...)
 
   # set sparse trafo in reg
-  reg[1].params[:sparseTrafo] = diagOp( repeat([sparseTrafo],numContr)... )
+  reg[1].params[:sparseTrafo] = DiagOp( repeat([sparseTrafo],numContr)... )
 
   W = WeightingOp( vcat(weights...), numChan )
 


### PR DESCRIPTION
Hi, 
I mostly generalized the input to abstract types as some operators in this package return type `subArray` and hence do not work well with this operator. 

Meanwhile.... I also fixed a bug for a missing `storage_type` function for `DiagOp` and I also capitalized all constructors of the latter type. The latter is a breaking change, but I found it kinda confusing (and was confused by it) that the main constructor and the convenience constructors had different capitalizations. 

Sorry for putting multiple things in on PR -- that was me being lazy. 