### PR TITLE
export function and correct SparseOp for echoes

### DIFF
--- a/MRIBase/src/Datatypes/AcqData.jl
+++ b/MRIBase/src/Datatypes/AcqData.jl
@@ -185,7 +185,7 @@ end
 returns the k-space contained in `acqData` for all echoes and given `coil`, `slice` and `rep`(etition).
 """
 function multiEchoData(acqData::AcquisitionData{T}, coil::Int64, slice::Int64;rep::Int64=1) where T
-  kdata = T[]
+  kdata = Complex{T}[]
   for echo=1:numContrasts(acqData)
     append!(kdata,acqData.kdata[echo,slice,rep][:,coil])
   end

--- a/MRIBase/src/Datatypes/AcqData.jl
+++ b/MRIBase/src/Datatypes/AcqData.jl
@@ -1,7 +1,7 @@
 export AcquisitionData, kData, kDataCart, kdataSingleSlice, convertUndersampledData,
        changeEncodingSize2D, convert3dTo2d, samplingDensity,
        numContrasts, numChannels, numSlices, numRepetitions,
-       encodingSize, fieldOfView, multiCoilData
+       encodingSize, fieldOfView, multiCoilData, multiCoilMultiEchoData
 
 """
 struct describing MRI acquisition data.

--- a/MRIOperators/src/EncodingOp.jl
+++ b/MRIOperators/src/EncodingOp.jl
@@ -1,4 +1,4 @@
-export EncodingOp, lrEncodingOp, fourierEncodingOp, encodingOps_simple, 
+export EncodingOp, lrEncodingOp, fourierEncodingOp, encodingOps_simple,
        encodingOps_parallel, encodingOp_multiEcho, encodingOp_multiEcho_parallel
 
 """
@@ -16,7 +16,7 @@ function encodingOps_simple(acqData::AcquisitionData{T,D}, shape::NTuple{D,Int64
   numContr = numContrasts(acqData)
   tr = [trajectory(acqData,i) for i=1:numContr]
   idx = acqData.subsampleIndices
-  return [fourierEncodingOp(shape, tr[i], "fast", 
+  return [fourierEncodingOp(shape, tr[i], "fast",
                  subsampleIdx=idx[i]; kargs...) for i=1:numContr]
 end
 
@@ -89,8 +89,8 @@ function encodingOp_multiEcho_parallel(acqData::AcquisitionData{T,D}, shape::NTu
   numChan = numChannels(acqData)
   # fourier operators
   ft = encodingOps_simple(acqData, shape; kargs...)
-  S = SensitivityOp(reshape(smaps,:,numChan),numContrasts(acqData)) 
-  return diagOp(repeat(ft, outer=numChan)...) ∘ S
+  S = SensitivityOp(reshape(smaps,:,numChan),numContrasts(acqData))
+  return diagOp(repeat(ft, inner=numChan)...) ∘ S
 end
 
 ###################################

--- a/src/Reconstruction/IterativeReconstruction.jl
+++ b/src/Reconstruction/IterativeReconstruction.jl
@@ -38,7 +38,7 @@ function reconstruction_simple( acqData::AcquisitionData{T}
 
   # reconstruction
   Ireco = zeros(Complex{T}, prod(reconSize), numSl, numContr, numChan, numRep)
-  #@floop 
+  #@floop
   for l = 1:numRep, k = 1:numSl
     if encodingOps!=nothing
       F = encodingOps[:,k]
@@ -247,6 +247,9 @@ function reconstruction_multiCoilMultiEcho(acqData::AcquisitionData{T}
   encParams = getEncodingOperatorParams(;params...)
 
   # set sparse trafo in reg
+  if isnothing(sparseTrafo)
+    sparseTrafo = SparseOp(Complex{T},"nothing", reconSize; params...)
+  end
   reg[1].params[:sparseTrafo] = diagOp( repeat([sparseTrafo],numContr)... )
 
   W = WeightingOp( vcat(weights...), numChan )

--- a/test/testReconstruction.jl
+++ b/test/testReconstruction.jl
@@ -633,34 +633,51 @@ function testRegridding(N=64)
 end
 
 function testReco(N=32)
-  @testset "Reconstructions" begin
-    testGriddingReco()
-    testConvertKspace()
-    testConvertKspace3D()
-    testGriddingReco3d()
-    sampling = ["random", "poisson", "vdPoisson"] # "lines"
-    for samp in sampling
-      testCSReco(sampling=samp)
+    @testset "Reconstructions" begin
+        @testset "MultiEcho" begin
+            testDirectRecoMultiEcho()
+            testSenseMultiEcho(N)
+        end
+
+        @testset "Convert k-space" begin
+            testConvertKspace()
+            testConvertKspace3D()
+        end
+
+        @testset "Gridding" begin
+            testGriddingReco()
+            testGriddingReco3d()
+            testRegridding()
+        end
+
+        @testset "CS" begin
+            sampling = ["random", "poisson", "vdPoisson"] # "lines"
+            for samp in sampling
+                testCSReco(sampling=samp)
+            end
+            testCSRecoMultCoil(type = ComplexF64)
+            testCSRecoMultCoil(type = ComplexF32)
+            testCSSenseReco()
+            testCSReco3d()
+            testCSSenseReco3d()
+            testCSRecoMultiCoilCGNR(type = ComplexF64)
+            testCSRecoMultiCoilCGNR(type = ComplexF32)
+        end
+
+        @testset "off-resonance" begin
+            accelMethods = ["nfft", "hist", "leastsquare"]
+            for a in accelMethods
+                !Sys.iswindows() && testOffresonanceReco(accelMethod=a)
+                !Sys.iswindows() && testOffresonanceSENSEReco()
+            end
+        end
+
+        @testset "SENSE" begin
+            testSENSEReco(64, ComplexF32)
+            testSENSEReco(64, ComplexF64)
+            testSENSEnoiseUnCorr(64, ComplexF64)
+        end
     end
-    testCSRecoMultCoil(type = ComplexF64)
-    testCSRecoMultCoil(type = ComplexF32)
-    testCSSenseReco()
-    testCSReco3d()
-    testCSSenseReco3d()
-    accelMethods = ["nfft", "hist", "leastsquare"]
-    for a in accelMethods
-      !Sys.iswindows() && testOffresonanceReco(accelMethod=a)
-    end
-    testSENSEReco(64, ComplexF32)
-    testSENSEReco(64, ComplexF64)
-    testSENSEnoiseUnCorr(64, ComplexF64)
-    testCSRecoMultiCoilCGNR(type = ComplexF64)
-    testCSRecoMultiCoilCGNR(type = ComplexF32)
-    !Sys.iswindows() && testOffresonanceSENSEReco()
-    testDirectRecoMultiEcho()
-    testSenseMultiEcho(N)
-    testRegridding()
-  end
 end
 
 testReco()


### PR DESCRIPTION
Correct some errors for multiCoilMultiEcho reconstruction.


# Instability in the reconstruction
Now the reconstruction returns images but I have a stability / reproductibility issue when the number of coils > 1

```julia
using ImageUtils: shepp_logan
using CairoMakie
using MRIReco, MRISimulation, MRICoilSensitivities

N = 64
nCoil = 4
T = Complex{Float32}

x = T.(shepp_logan(N))

coilsens = T.(birdcageSensitivity(N, nCoil, 1.5))

# simulation
params = Dict{Symbol, Any}()
params[:simulation] = "fast"
params[:trajName] = "Cartesian"
params[:numProfiles] = floor(Int64, N)
params[:numSamplingPerProfile] = N
params[:senseMaps] = coilsens

acqData = simulation( real(x), params )

params = Dict{Symbol, Any}()
params[:reconSize] = (N,N)
params[:reco] = "multiCoil"
params[:regularization] = "L2"
params[:λ] = 1.e-3
params[:iterations] = 1
params[:solver] = "cgnr"
params[:senseMaps] = reshape(coilsens,N,N,1,nCoil)

x_approx = reshape(reconstruction(acqData,params),N,N,:)

# Reco multiCoilMultiEcho
params2 = Dict{Symbol, Any}()
params2[:reconSize] = (N,N)
params2[:reco] = "multiCoilMultiEcho"
#params[:sparseTrafo] = "nothing" #"nothing" #sparse trafo
params2[:regularization] = "L2"
params2[:λ] = 1.e-3
params2[:iterations] = 1
params2[:solver] = "cgnr"
params2[:senseMaps] = reshape(coilsens,N,N,1,nCoil)

x_approx2= reshape(reconstruction(acqData,params2),N,N,:)


f=Figure()
for i = 1:8
    x_approx = reshape(reconstruction(acqData,params),N,N,:)
    heatmap!(Axis(f[i,1],aspect = 1),abs.(x_approx[:,:,1]))
    hidedecorations!(current_axis())
    
    x_approx2= reshape(reconstruction(acqData,params2),N,N,:)
    heatmap!(Axis(f[i,2],aspect=1),abs.(x_approx2[:,:,1]))
    hidedecorations!(current_axis())
end
f
````
which returns (left : MultiCoil reco / right : multiCoilEchoes): 
<img width="409" alt="image" src="https://user-images.githubusercontent.com/12255163/228833721-08105bc1-4fe1-40d3-8c7c-69264b8f481b.png">


# Decomposition of the operator
I also get that error with the code bellow (which only used the operators)
```julia
## test operator
kdata = multiCoilMultiEchoData(acqData, 1)
encParams = MRIReco.getEncodingOperatorParams(;params...)
E = encodingOp_multiEcho_parallel(acqData, (N,N), reshape(coilsens,N,N,1,nCoil); slice=1)

f = Figure()
for i = 1:4,j=1:4
    im_reco = E'*kdata
    im_reco = reshape(im_reco,N,N,:)

    heatmap!(Axis(f[i,j],aspect=1),abs.(im_reco[:,:,1]))
    hidedecorations!(current_axis())
end
f
```
<img width="640" alt="image" src="https://user-images.githubusercontent.com/12255163/228837850-ddc4caf2-c392-440c-afd3-024f5bc34d10.png">

I don't think it is an issue with the simulation because I also get the same kind of results on my real data