### PR TITLE
Fix fieldmap nfft copy

### DIFF
--- a/MRIOperators/src/FieldmapNFFTOp.jl
+++ b/MRIOperators/src/FieldmapNFFTOp.jl
@@ -134,10 +134,13 @@ function Base.copy(S::FieldmapNFFTOp{T,Nothing,Function,D}) where {T,D}
   D_ = length(shape)
   circTraj = S.circTraj
 
+  mul! = (res,x) -> produ!(res,x,x_tmp,shape,plans,idx,cparam,circTraj,d,p)
+  ctmul! = (res,y) -> ctprodu!(res,y,y_tmp,shape,plans,idx,cparam,circTraj,d,p)
+
   return FieldmapNFFTOp{T,Nothing,Function,D_}(S.nrow, S.ncol, false, false
-            , (res,x) -> produ!(res,x,x_tmp,shape,plans,idx,cparam,circTraj,d,p)
+            , mul!
             , nothing
-            , (res,y) -> ctprodu!(res,y,y_tmp,shape,plans,idx,cparam,circTraj,d,p), 0, 0, 0, false, false, false, Complex{T}[], Complex{T}[]
+            , ctmul!, 0, 0, 0, false, false, false, Complex{T}[], Complex{T}[]
             , plans, idx, circTraj, shape, cparam)
 end
 

--- a/MRIOperators/src/FieldmapNFFTOp.jl
+++ b/MRIOperators/src/FieldmapNFFTOp.jl
@@ -33,6 +33,11 @@ mutable struct FieldmapNFFTOp{T,F1,F2,D} <:AbstractLinearOperator{Complex{T}}
   circTraj::Bool
   shape::NTuple{D,Int64}
   cparam::InhomogeneityData{T}
+  d::Vector{Vector{T}}
+  p::Vector{Array{T,D}}
+  x_tmp::Vector{Complex{T}}
+  y_tmp::Vector{Complex{T}}
+
 end
 
 LinearOperators.storage_type(op::FieldmapNFFTOp) = typeof(op.Mv5)
@@ -81,6 +86,10 @@ function FieldmapNFFTOp(shape::NTuple{D,Int64}, tr::Trajectory,
   nrow = size(nodes,2)
   ncol = prod(shape)
 
+  x_tmp = zeros(Complex{T}, ncol)
+  y_tmp = zeros(Complex{T}, nrow)
+
+
  # create and truncate low-rank expansion
   cparam = createInhomogeneityData_(vec(times), correctionmap; K=K, alpha=alpha, m=m, method=method, K_tol=K_tol, numSamp=numSamplingPerProfile(tr),step=step)
   K = size(cparam.A_k,2)
@@ -93,45 +102,46 @@ function FieldmapNFFTOp(shape::NTuple{D,Int64}, tr::Trajectory,
     idx[κ] = findall(x->x!=0.0, cparam.A_k[:,κ])
     plans[κ] = plan_nfft(nodes[:,idx[κ]], shape, m=3, σ=1.25, precompute = NFFT.POLYNOMIAL)
   end
-
+  
   d = [zeros(ComplexF64, length(idx[κ])) for κ=1:K ]
   p = [zeros(Complex{T}, shape) for κ=1:K]
-  x_tmp = zeros(Complex{T}, ncol)
-  y_tmp = zeros(Complex{T}, nrow)
-  
+
   circTraj = isCircular(tr)
 
-  mul! = (res,x) -> produ!(res,x,x_tmp,shape,plans,idx,cparam,circTraj,d,p)
-  ctmul! = (res,y) -> ctprodu!(res,y,y_tmp,shape,plans,idx,cparam,circTraj,d,p)
-
   return FieldmapNFFTOp{T,Nothing,Function,D}(nrow, ncol, false, false
-            , mul!
+            , (res,x) -> produ!(res,x,x_tmp,shape,plans,idx,cparam,circTraj,d,p)
             , nothing
-            , ctmul!, 0, 0, 0, false, false, false, ComplexF64[], ComplexF64[]
-            , plans, idx, circTraj, shape, cparam)
+            , (res,y) -> ctprodu!(res,y,y_tmp,shape,plans,idx,cparam,circTraj,d,p), 0, 0, 0, false, false, false, ComplexF64[], ComplexF64[]
+            , plans, idx, circTraj, shape, cparam,d,p,x_tmp,y_tmp)
+end
+
+function Base.copy(cparam::InhomogeneityData{T}) where T
+
+  return cparam
+
 end
 
 function Base.copy(S::FieldmapNFFTOp{T,Nothing,Function,D}) where {T,D}
+
   K=length(S.plans)
   plans = [copy(S.plans[i]) for i=1:K]
-  idx = deepcopy(S.idx)
+  idx = copy(S.idx)
 
-  d = [zeros(Complex{T}, length(idx[κ])) for κ=1:K ]
-  p = [zeros(Complex{T}, S.shape) for κ=1:K]
-  x_tmp = zeros(Complex{T}, S.ncol)
-  y_tmp = zeros(Complex{T}, S.nrow)
-
-  cparam = deepcopy(S.cparam)
-
-  mul! = (res,x) -> produ!(res,x,x_tmp,S.shape,plans,idx,cparam,S.circTraj,d,p)
-  ctmul! = (res,y) -> ctprodu!(res,y,y_tmp,S.shape,plans,idx,cparam,S.circTraj,d,p)
+  cparam = copy(S.cparam)
+  d = copy(S.d)
+  p = copy(S.p)
+  x_tmp = copy(S.x_tmp)
+  y_tmp = copy(S.y_tmp)
 
   D_ = length(S.shape)
+  circTraj = S.circTraj
+  shape = S.shape
+
   return FieldmapNFFTOp{T,Nothing,Function,D_}(S.nrow, S.ncol, false, false
-            , mul!
+            , (res,x) -> produ!(res,x,x_tmp,shape,plans,idx,cparam,circTraj,d,p)
             , nothing
-            , ctmul!, 0, 0, 0, false, false, false, Complex{T}[], Complex{T}[]
-            , plans, idx, S.circTraj, S.shape, cparam)
+            , (res,y) -> ctprodu!(res,y,y_tmp,shape,plans,idx,cparam,circTraj,d,p), 0, 0, 0, false, false, false, Complex{T}[], Complex{T}[]
+            , plans, idx, circTraj, shape, cparam,d,p,x_tmp,y_tmp)
 end
 
 function produ!(s::AbstractVector{T}, x::AbstractVector{T}, x_tmp::Vector{T},shape::Tuple, plan,

--- a/MRIOperators/test/testOperators.jl
+++ b/MRIOperators/test/testOperators.jl
@@ -169,6 +169,34 @@ function testSparseOp(T::Type,shape)
     @test (norm(xapprox-x)/norm(x)) < 1e-3
 end
 
+## test FieldmapNFFTOp
+function testCopySizes(N=16)
+  # random image
+  x = zeros(ComplexF64,N,N)
+  for i=1:N,j=1:N
+    x[i,j] = rand()
+  end
+
+  tr = CartesianTrajectory(Float64,N,N;TE=0.0,AQ=0.01)
+  times = readoutTimes(tr)
+  nodes = kspaceNodes(tr)
+  cmap = im*quadraticFieldmap(N,N)[:,:,1]
+
+  # FourierMatrix
+  idx = CartesianIndices((N,N))[collect(1:N^2)]
+
+  # Operators
+
+  F_nfft = NFFTOp((N,N),tr,symmetrize=false)
+  F_fmap_nfft = FieldmapNFFTOp((N,N),tr,cmap,symmetrize=false)
+
+  # Copy the FieldmapNFFTOp operator and change the plans field of the new operator to empty 
+  F_fmap_nfft_copy = copy(F_fmap_nfft)
+  F_nfft_copy = copy(F_nfft)
+
+  @test sizeof(F_fmap_nfft_copy) == sizeof(F_fmap_nfft)
+
+end
 
 function testOperators()
   @testset "Linear Operator" begin


### PR DESCRIPTION
Fix copying of `FieldmapNFFTOp` to return a copy that is the same size in memory as the original op. Prior to this PR, copying a FieldmapNFFTOp would return a copy larger than the original in memory.  