### PR TITLE
Fix espirit for odd matrix sizes

### DIFF
--- a/MRICoilSensitivities/src/espirit.jl
+++ b/MRICoilSensitivities/src/espirit.jl
@@ -90,7 +90,7 @@ function espirit(calibData::Array{T}, imsize::NTuple{D,Int}, ksize::NTuple{D,Int
   maps .*= msk
   maps_ = fftshift(maps, 1:length(imsize))
 
-  return maps_, W
+  return maps_
 end
 
 #


### PR DESCRIPTION
ESPIRIT did not work for odd matrix sizes. The bug was essentially a missing `ifftshift`, which we implemented in a non-allocating way. 