### PR TITLE
MRIFiles.jl: Additional `<userParameters>` tag is included within XML header of exported MRD

### DIFF
--- a/MRIFiles/Project.toml
+++ b/MRIFiles/Project.toml
@@ -1,7 +1,7 @@
 name = "MRIFiles"
 uuid = "5a6f062f-bf45-497d-b654-ad17aae2a530"
 author = ["Tobias Knopp <tobias@knoppweb.de>"]
-version = "0.2.0"
+version = "0.2.1"
 
 [deps]
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"

--- a/MRIFiles/src/ISMRMRD/Parameters.jl
+++ b/MRIFiles/src/ISMRMRD/Parameters.jl
@@ -310,7 +310,7 @@ function insertNode(xs, paramName::String, param::Limit)
 end
 
 function insertNode(xs, paramName::String, param_::Dict{String,Any})
-  xsp = new_child(xs, paramName)
+  xsp = paramName == "userParameters" ? xs : new_child(xs, paramName)  
   param = deepcopy(param_)
   if haskey(param, "comment")
     insertNode(xsp, "comment", param["comment"])

--- a/MRIFiles/src/ISMRMRD/Parameters.jl
+++ b/MRIFiles/src/ISMRMRD/Parameters.jl
@@ -310,7 +310,7 @@ function insertNode(xs, paramName::String, param::Limit)
 end
 
 function insertNode(xs, paramName::String, param_::Dict{String,Any})
-  xsp = paramName == "userParameters" ? xs : new_child(xs, paramName)  
+  xsp = paramName == "userParameters" ? xs : new_child(xs, paramName)
   param = deepcopy(param_)
   if haskey(param, "comment")
     insertNode(xsp, "comment", param["comment"])


### PR DESCRIPTION
Fixes: 
- cncastillo/KomaMRI.jl#236

More information can be found on https://github.com/cncastillo/KomaMRI.jl/issues/214, but basically the additional tag crashes Python's MRD reader. 

I preserved the current behaviour for `paramName != "userParameters"`.