### PR TITLE
Add option for vectors and tuples

### DIFF
--- a/MRIOperators/src/MRIOperators.jl
+++ b/MRIOperators/src/MRIOperators.jl
@@ -106,11 +106,15 @@ LinearOperators.storage_type(op::DiagOp) = typeof(op.Mv5)
 
 
 """
-    DiagOp(ops :: AbstractLinearOperator...)
+    DiagOp(ops::AbstractLinearOperator...)
+    DiagOp(ops::Vector{AbstractLinearOperator})
+    DiagOp(ops::NTuple{N,AbstractLinearOperator})
 
 create a bloc-diagonal operator out of the `LinearOperator`s contained in ops
 """
-function DiagOp(ops :: AbstractLinearOperator...)
+DiagOp(ops::AbstractLinearOperator...) = DiagOp(ops)
+
+function DiagOp(ops)
   nrow = 0
   ncol = 0
   S = eltype(ops[1])


### PR DESCRIPTION
Hi,
this is a minor change adding the option to call DiagOp with a vector of operators or an NTuple of Operators. My goal is to prevent having to use the `splat` operator to improve speed. 

The change should be non-breaking. 

@tknopp: If approved, would you mind taking care of the release, as I still don't know how to release this multi-package system of MRIReco.jl

Thank you!!