### PR TITLE
MRIFiles: Fixing `save` of `ISMRMRDFile`'s in Julia 1.11 and 1.12

### DIFF
--- a/MRIFiles/Project.toml
+++ b/MRIFiles/Project.toml
@@ -1,7 +1,7 @@
 name = "MRIFiles"
 uuid = "5a6f062f-bf45-497d-b654-ad17aae2a530"
 author = ["Tobias Knopp <tobias@knoppweb.de>"]
-version = "0.3.1"
+version = "0.3.2"
 
 [deps]
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"

--- a/MRIFiles/src/ISMRMRD/HDF5Types.jl
+++ b/MRIFiles/src/ISMRMRD/HDF5Types.jl
@@ -245,7 +245,7 @@ function writeProfiles(file, dataset, profiles::Vector{Profile})
     #for some reason this is stored as float
     d = HVL_T(2*length(profiles[l].data), pointer(reinterpret(Float32,profiles[l].data)))
 
-    iobuf = IOBuffer()
+    iobuf = IOBuffer(sizehint=ISMRMRD_HEADER_PLUS_POINTERS_SIZE)
     write(iobuf, profiles[l].head )
     write(iobuf, t )
     write(iobuf, d)


### PR DESCRIPTION
The `write(IO, ...)` function used in `writeProfiles` now uses the new `Memory` type that behaves a little differently. From Julia 1.11 changelogs:

> New `Memory` type that provides a lower-level container as an alternative to `Array`. `Memory` has less overhead and a faster constructor, making it a good choice for situations that do not need all the features of `Array` (e.g. multiple dimensions). Most of the `Array` type is now implemented in Julia on top of `Memory`, leading to significant speedups for several functions (e.g. `push!`) as well as more maintainable code ([#51319](https://github.com/JuliaLang/julia/issues/51319)).

> The fallback method `write(::IO, ::AbstractArray)` used to recursively call `write` on each element, but now writes the in-memory representation of each value. For example, `write(io, 'a':'b')` now writes 4 bytes for each character, instead of writing the UTF-8 representation of each character. The new format is compatible with that used by `Array`, making it possible to use `read!` to get the data back ([#42593](https://github.com/JuliaLang/julia/issues/42593)).

In this PR, I added a `sizehint` argument to the `IOBuffer` (that was also available pre-Julia 1.11), as without it, the `write` function was adding extra bytes of random information when the added data surpassed the current `Memory` capacity in `iobuf.data`.

Fixes #194 