### PR TITLE
FixDataRaceBug

### DIFF
--- a/MRICoilSensitivities/Project.toml
+++ b/MRICoilSensitivities/Project.toml
@@ -4,33 +4,29 @@ author = ["Tobias Knopp <tobias@knoppweb.de>"]
 version = "0.1.3"
 
 [deps]
-Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
-MRIBase = "f7771a9a-6e57-4e71-863b-6e4b6a2f17df"
-LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
-Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
-FLoops = "cc61a311-1640-44b5-9fba-1b764f453329"
 FFTW = "7a1cc6ca-52ef-59f5-83cd-3a7055c09341"
+FLoops = "cc61a311-1640-44b5-9fba-1b764f453329"
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+MRIBase = "f7771a9a-6e57-4e71-863b-6e4b6a2f17df"
+OhMyThreads = "67456a42-1dca-4109-a031-0a68de7e3ad5"
+Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 
 [compat]
-julia = "1.6"
-MRIBase = "0.3, 0.4"
-Reexport = "1"
+FFTW = "1.0"
 FLoops = "0.2"
 ImageUtils = "0.2.5"
-FFTW = "1.0"
-
+MRIBase = "0.3, 0.4"
+OhMyThreads = "0.8.3"
+Reexport = "1"
+julia = "1.6"
 
 [extras]
-Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 ImageUtils = "8ad4436d-4835-5a14-8bce-3ae014d2950b"
-MRISimulation = "8988da37-ea20-4fa6-9af7-8a6f6f9a8970"
-MRISampling = "9be66c26-f988-4649-80fc-f4721a4a33f2"
 MRIReco = "bdf86e05-2d2b-5731-a332-f3fe1f9e047f"
+MRISampling = "9be66c26-f988-4649-80fc-f4721a4a33f2"
+MRISimulation = "8988da37-ea20-4fa6-9af7-8a6f6f9a8970"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
 test = ["Test", "ImageUtils", "MRISimulation", "MRISampling", "MRIReco"]
-
-
-
-
-

--- a/MRICoilSensitivities/Project.toml
+++ b/MRICoilSensitivities/Project.toml
@@ -5,7 +5,6 @@ version = "0.1.3"
 
 [deps]
 FFTW = "7a1cc6ca-52ef-59f5-83cd-3a7055c09341"
-FLoops = "cc61a311-1640-44b5-9fba-1b764f453329"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 MRIBase = "f7771a9a-6e57-4e71-863b-6e4b6a2f17df"
 OhMyThreads = "67456a42-1dca-4109-a031-0a68de7e3ad5"
@@ -14,7 +13,6 @@ Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 
 [compat]
 FFTW = "1.0"
-FLoops = "0.2"
 ImageUtils = "0.2.5"
 MRIBase = "0.3, 0.4"
 OhMyThreads = "0.8.3"

--- a/MRICoilSensitivities/src/MRICoilSensitivities.jl
+++ b/MRICoilSensitivities/src/MRICoilSensitivities.jl
@@ -3,7 +3,6 @@ module MRICoilSensitivities
 export estimateCoilSensitivities, mergeChannels, espirit, geometricCoilCompression
 
 using MRIBase
-using FLoops
 using OhMyThreads: @tasks, @local
 using LinearAlgebra
 using FFTW

--- a/MRICoilSensitivities/src/MRICoilSensitivities.jl
+++ b/MRICoilSensitivities/src/MRICoilSensitivities.jl
@@ -4,6 +4,7 @@ export estimateCoilSensitivities, mergeChannels, espirit, geometricCoilCompressi
 
 using MRIBase
 using FLoops
+using OhMyThreads: @tasks, @local
 using LinearAlgebra
 using FFTW
 

--- a/MRICoilSensitivities/src/espirit.jl
+++ b/MRICoilSensitivities/src/espirit.jl
@@ -162,9 +162,11 @@ function kernelEig(kernel::Array{T}, imsize::Tuple, nmaps=1; use_poweriterations
     @views kernel_k[CartesianIndices(ksize), :] .= kernel[CartesianIndices(ksize), iv, :]
     mul!(kernel_i, fftplan, kernel_k)
 
-    @floop for j ∈ axes(kernel_i, ndims(kernel_i)), ix ∈ CartesianIndices(sizePadded)
-      @inbounds @simd for i ∈ axes(kernel_i, ndims(kernel_i))
-        kern2_[i, j, ix] += conj(kernel_i[ix, i]) * kernel_i[ix, j]
+    @tasks for ix ∈ CartesianIndices(sizePadded)
+      for j ∈ axes(kernel_i, ndims(kernel_i))
+        @inbounds @simd for i ∈ axes(kernel_i, ndims(kernel_i))
+          kern2_[i, j, ix] += conj(kernel_i[ix, i]) * kernel_i[ix, j]
+        end
       end
     end
   end


### PR DESCRIPTION
Hi everyone,

the ESPIRIT code used `threadid`, which is not safe with dynamic scheduling and will error for sure w/ Julia 1.12. I replaced this with task-local variables. I also removed FLoops. jl from the dependencies in order avoid having multiple threading packages as dependencies – and the switch did actually speed up the test code from 36s to 31.5s on my computer. 