### PR TITLE
MRIFiles: fix waveformName/waveformType parsed as Float64 instead of String

### DIFF
--- a/MRIFiles/src/ISMRMRD/Parameters.jl
+++ b/MRIFiles/src/ISMRMRD/Parameters.jl
@@ -190,8 +190,8 @@ function GeneralParameters(xdoc::XMLDocument)
     # waveformInformation
     e = get_elements_by_tagname(LightXML.root(xdoc),"waveformInformation")
     if !isempty(e)
-      addToDict!(params, e[1], "waveformName", Float64)
-      addToDict!(params, e[1], "waveformType", Float64)
+      addToDict!(params, e[1], "waveformName", String)
+      addToDict!(params, e[1], "waveformType", String)
 
       if !isempty(e[1]["userParameters"])
           d = e[1]["userParameters"]

--- a/MRIFiles/src/ISMRMRD/Parameters.jl
+++ b/MRIFiles/src/ISMRMRD/Parameters.jl
@@ -187,14 +187,18 @@ function GeneralParameters(xdoc::XMLDocument)
       addToDict!(params, e[1], "echo_spacing", Float64)
     end
 
-    # waveformInformation
+    # waveformInformation — up to 32 entries per spec (maxOccurs="32")
     e = get_elements_by_tagname(LightXML.root(xdoc),"waveformInformation")
     if !isempty(e)
-      addToDict!(params, e[1], "waveformName", String)
-      addToDict!(params, e[1], "waveformType", String)
-
-      if !isempty(e[1]["userParameters"])
-          d = e[1]["userParameters"]
+      waveforms = Vector{Dict{String,Any}}()
+      for wi in e
+        w = Dict{String,Any}()
+        n = wi["waveformName"]
+        if !isempty(n); w["waveformName"] = content(n[1]); end
+        t = wi["waveformType"]
+        if !isempty(t); w["waveformType"] = content(t[1]); end
+        if !isempty(wi["userParameters"])
+          d = wi["userParameters"]
           y = Dict{String,Any}()
           for q in d["userParameterLong"]
             y[content(q["name"][1])] = parse(Int,content(q["value"][1]))
@@ -205,8 +209,11 @@ function GeneralParameters(xdoc::XMLDocument)
           for q in d["userParameterString"]
             y[content(q["name"][1])] = content(q["value"][1])
           end
-          params["waveformUserParameters"] = y
+          w["userParameters"] = y
+        end
+        push!(waveforms, w)
       end
+      params["waveformInformation"] = waveforms
     end
 
     # UserParameters
@@ -394,8 +401,14 @@ function GeneralParametersToXML(params::Dict{String,Any})
   p = ["TR", "TE", "TI", "flipAngle_deg", "sequence_type", "echo_spacing"]
   generateGroup(params, p, xroot, "sequenceParameters")
 
-  p = ["waveformName", "waveformType", "waveformUserParameters"]
-  generateGroup(params, p, xroot, "waveformInformation")
+  if haskey(params, "waveformInformation")
+    for w in params["waveformInformation"]
+      xs = new_child(xroot, "waveformInformation")
+      if haskey(w, "waveformName"); insertNode(xs, "waveformName", w["waveformName"]); end
+      if haskey(w, "waveformType"); insertNode(xs, "waveformType", w["waveformType"]); end
+      if haskey(w, "userParameters"); insertNode(xs, "userParameters", w["userParameters"]); end
+    end
+  end
 
   p = ["userParameters"]
   generateGroup(params, p, xroot, "userParameters")

--- a/MRIFiles/test/testISMRMRD.jl
+++ b/MRIFiles/test/testISMRMRD.jl
@@ -49,6 +49,21 @@ h5open(filenameCopy) do fd
   end
 end
 
+# Test header with waveform
+
+let xml = """<?xml version="1.0"?>
+<ismrmrdHeader xmlns="http://www.ismrm.org/ISMRMRD/xsd"
+               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <waveformInformation>
+    <waveformName>ecg_trigger</waveformName>
+    <waveformType>ECG</waveformType>
+  </waveformInformation>
+</ismrmrdHeader>"""
+  p = MRIFiles.GeneralParameters(xml)
+  @test p["waveformName"] == "ecg_trigger"
+  @test p["waveformType"] == "ECG"
+end
+
 # test reconstructing the data
 IrecoCopy = reconstruction(AcquisitionData(acqCopy), params)
 
@@ -81,10 +96,12 @@ save(fCopy, acq)
 acqCopy = RawAcquisitionData(f)
 
 io = IOBuffer()
-write(IOBuffer(), acq.profiles[1].head)
+write(io, acq.profiles[1].head)
 ioCopy = IOBuffer()
-write(IOBuffer(), acqCopy.profiles[1].head)
-@test io.data == ioCopy.data
+write(ioCopy, acqCopy.profiles[1].head)
+seekstart(io)
+seekstart(ioCopy)
+@test read(io) == read(ioCopy)
 @test acqCopy.profiles[1].traj == acq.profiles[1].traj
 @test acqCopy.profiles[1].data == acq.profiles[1].data
 

--- a/MRIFiles/test/testISMRMRD.jl
+++ b/MRIFiles/test/testISMRMRD.jl
@@ -49,19 +49,30 @@ h5open(filenameCopy) do fd
   end
 end
 
-# Test header with waveform
+# Test waveformInformation: single entry, multiple entries, and round-trip
 
 let xml = """<?xml version="1.0"?>
 <ismrmrdHeader xmlns="http://www.ismrm.org/ISMRMRD/xsd"
                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <waveformInformation>
     <waveformName>ecg_trigger</waveformName>
-    <waveformType>ECG</waveformType>
+    <waveformType>ecg</waveformType>
+  </waveformInformation>
+  <waveformInformation>
+    <waveformName>resp</waveformName>
+    <waveformType>respiratory</waveformType>
   </waveformInformation>
 </ismrmrdHeader>"""
   p = MRIFiles.GeneralParameters(xml)
-  @test p["waveformName"] == "ecg_trigger"
-  @test p["waveformType"] == "ECG"
+  @test length(p["waveformInformation"]) == 2
+  @test p["waveformInformation"][1]["waveformName"] == "ecg_trigger"
+  @test p["waveformInformation"][1]["waveformType"] == "ecg"
+  @test p["waveformInformation"][2]["waveformName"] == "resp"
+  @test p["waveformInformation"][2]["waveformType"] == "respiratory"
+  # round-trip through XML serialisation
+  xml2 = MRIFiles.GeneralParametersToXML(p)
+  p2 = MRIFiles.GeneralParameters(xml2)
+  @test p2["waveformInformation"] == p["waveformInformation"]
 end
 
 # test reconstructing the data


### PR DESCRIPTION
- `waveformInformation` fields `waveformName` and `waveformType` were typed as `Float64` in `addToDict!`, causing `ArgumentError: cannot parse "ECG" as Float64` for any ISMRMRD file that contains a `waveformInformation` block. Both fields are XML strings (`waveformType` is an enum: `ECG`, `NOISE`, `GADGETRON_TRIGGER`, …). Fix: pass `String` as the type argument.
- parse all waveformInformation entries as a list as the ISMRMRD schema allows up to 32 waveformInformation elements per header
- Adds a regression test that directly exercises the XML parsing path with a string `waveformType`.
- Also fixes a pre-existing test bug in the spiral-data section of `testISMRMRD.jl` where `write(IOBuffer(), ...)` silently discarded writes to anonymous buffers instead of writing to the named `io`/`ioCopy` buffers under test.